### PR TITLE
修复了世界观模块拼接prompt时的错误重复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,103 @@
 # Changelog
 
+## v3.4.0.2 — 2026-06-14 · 创作上下文透明化 · 高级模式 · budget 可调
+
+> 这一轮把项目里所有"AI 实际能看到 / 看不到什么"的内部参数从代码深处搬到台面上：
+>
+> - 新增 **「高级模式」总开关**（默认关，避免普通用户面对一长串内部参数）；
+> - 在所有作者写字的字段下加 **硬截断阈值文本提示与超限警告**（不阻断输入；普通用户也能看到，与高级模式解耦）；
+> - 在大纲 / 正文写作面板加 **「查看注入 prompt」按钮**，能完整展示送给 AI 的 messages、各上下文段与 token 占用；
+> - 把所有 **budget / 截断阈值** 集中到「高级设置」子面板，**支持运行时调整**并立刻生效（含 33 个 leaf：装配总闸 / 19 个 source 预算 / 6 类 reader / 字段格式化 / Prompt 引擎）。
+>
+> 数据安全：纯前端项目，**零 schema 变更、零数据迁移**；用户调整持久化在 localStorage（key = `storyforge.effectiveLimits.v1`），随时可一键全部恢复默认。
+
+### ✨ 高级模式总开关（设置 → 高级设置）
+
+- 顶部一个开关，OFF 时面板里只显示开关本身和说明文，**不暴露任何内部参数**；ON 后才展开 budget 表格，并解锁后续高级入口。
+- 设计原则：开源项目里普通用户不应被一长串技术参数淹没；只有显式同意进入高级模式才会看到这些。
+- 持久化在 localStorage，跨刷新 / 跨标签页保留状态；通过 `CustomEvent` 广播让所有订阅组件实时跟随。
+- **不受开关影响的内容（始终对所有用户可见）**：业务字段下的「硬截断阈值文本提示」与「超限警告」（见下一节）。
+
+### ✨ 字段硬截断 · 文本提示 + 超限软警告（始终可见）
+
+- 在故事核心、角色、创作规则、历史年表 4 个高优先级面板里，每个会被 AI 截断的字段下方加一行小字：
+  - 默认灰色：`截断阈值：N 字（当前 X）。<说明>`
+  - 超出阈值：升级为琥珀色 + AlertTriangle，显示"已超出 K 字 · 超出部分不会进入 AI 上下文"。
+- **不阻断输入**：作者粘贴 5000 字也不会被卡，超限提示只是软警告。
+- 字段示例：
+  - 故事核心：`故事主线（≤ 250 字）` / `故事复线（≤ 200 字）`
+  - 角色：`外貌 / 性格 / 动机 / 能力 / 弧光（≤ 150 字）`、`背景（≤ 200 字）`、`关系（仅 supporting 档位注入；≤ 80 字）`
+  - 创作规则：`写作风格 / 特殊要求（≤ 200 字）`、`基调氛围（≤ 150 字）`
+  - 历史年表：`事件描述（≤ 80 字）` / `关键词描述（≤ 40 字）`
+- `角色 · 关系` 的提示文案专门写明 **"主角 / 反派档位中此字段不会进入 AI 上下文"**，与 `buildCharacterContext` 的真实档位行为对齐，避免作者写完发现没用上。
+
+### ✨ 「查看注入 prompt」按钮（仅高级模式）
+
+- 大纲面板：「AI 生成卷级大纲」下方 + 选中卷后「AI 生成章节」旁，分别新增 `🔍 查看注入 prompt`。
+- 正文面板：「✨ 生成正文 / 📝 续写」之后，新增两个 `🔍 查看 prompt` 按钮（生成 / 续写各一个）。
+- 弹出的 Modal 三层信息：
+  - **顶部统计栏**：`message 总 token` / `assembleContext 总 token / 总闸` / `模型窗口占比` / `system / user message 数`。
+  - **上下文段表格**：每段 `label / layer / 字符 / token（估算）/ 是否被 source 预算截断`；列出 `trimmed`（被整层裁剪的源）和 `omitted`（缺前置条件 / enabled 返回 false / 字段为空）。
+  - **Messages 折叠区**：每条 `system / user` 都可单独展开看完整内容，带"复制"按钮。
+- **与真实生成完全同口径**：装配函数复用 `buildOutlineAssembledContext / buildFullWorldCtx`，调用同一组 adapter，确保看到的就是真实送给 AI 的 prompt。
+- 仅高级模式开启时按钮才存在；按钮可见性受开关控制，但 Modal 自身的渲染口径与运行时一致，没有"看到的不是真的发出的"这种漂移。
+
+### ✨ Budget / 截断阈值 · 集中可调（高级设置）
+
+将原本散落在多个文件的硬编码集中到 [src/lib/registry/budget-config.ts](src/lib/registry/budget-config.ts) 作为单点事实清单，并通过 [src/lib/registry/effective-limits.ts](src/lib/registry/effective-limits.ts) 提供 `getEffectiveLimit(key, fallback)` 同步读取层。所有运行时读取点改为「`getEffectiveLimit(key, 默认值)`」，未覆盖时行为完全等同于以前的硬编码。
+
+可调参数共 **33 个 leaf**，按 5 个分组列在「高级设置」子面板里：
+
+| 分组 | 数量 | 覆盖范围 |
+|---|---|---|
+| **装配总闸** | 1 | `assembleContext` 装配后总 token 上限（默认 24,000）。超出按 L3 → L2 → L1 整层裁剪。 |
+| **上下文源预算** | 19 | `CONTEXT_SOURCES` 各 source 的 `budgetTokens`（每个 source 自己的 token 硬上限，先于装配总闸生效）。 |
+| **Reader 截断** | 6 项（多子字段共 12 leaf） | 各 source 的 reader 函数内部写死的"条数 + 单条字符"，包括伏笔 / 故事线 / 状态卡 / 重要地点 / 历史时间线（含事件描述 80、关键词描述 40）/ 设定词条。 |
+| **字段格式化截断** | 13 | `context-builder` 序列化角色、故事核心、创作规则等字段时的 slice 上限。 |
+| **Prompt 引擎截断** | 4 | `renderPrompt` few-shot 数量、`buildContinuePrompt` 取尾长度、`ChapterEditor` 前一章结尾长度。 |
+
+操作行为：
+
+- 每行右侧一个数字输入框 + 「↺」单项恢复按钮；失焦或回车提交。
+- 留空 / 非正数 / 显式写回默认值 → 视为"恢复默认"，输入框边框回灰。
+- 已覆盖：边框琥珀色 + 「覆盖中」标签；提交成功 1.2 秒内显示绿色「已保存」。
+- 头部统计「已覆盖 N 项默认值」+ 「全部恢复默认」按钮（带 confirm）。
+- 跨标签页同步：监听原生 `storage` 事件，缓存自动失效。
+
+### 🛠 修复：业务面板的字段提示未跟随高级设置变化
+
+> 自查发现的回归：AI 写作链路读 `getEffectiveLimit`，但**面板上的 `FieldLimitHint` 仍然把 limit 写死为字面量**，导致用户在高级设置改了 `角色 · 外貌` 阈值后，注入 prompt 是新值，但角色面板下方的提示文案还是默认 150。
+
+- 新增 `useEffectiveLimit(key, fallback)` React hook，读 effective-limits 并自动订阅变更广播。
+- [`CharacterPanel`](src/components/character/CharacterPanel.tsx) / [`CreativeRulesPanel`](src/components/rules/CreativeRulesPanel.tsx) / [`StoryCorePanel`](src/components/worldview/StoryCorePanel.tsx) / [`HistoryPanel`](src/components/history/HistoryPanel.tsx) 的 `FieldLimitHint` `limit` prop 改为读 hook，UI 与 AI 实际截断口径**实时一致**。
+- 顺带：把历史年表里原本没在 budget-config 暴露的 `事件描述（80）` / `关键词描述（40）` 两条也补进 `reader.historical.*`，并让 `buildHistoricalContext` 走 `getEffectiveLimit`。这两条也成为「高级设置」可调 leaf。
+
+### 📦 新增 / 调整文件
+
+| 文件 | 角色 |
+|---|---|
+| [src/hooks/useAdvancedMode.ts](src/hooks/useAdvancedMode.ts) | 高级模式开关 hook（订阅 + 同步读 + 广播） |
+| [src/lib/registry/budget-config.ts](src/lib/registry/budget-config.ts) | budget / 截断阈值的单点事实清单 + `flattenBudgetEntry` |
+| [src/lib/registry/effective-limits.ts](src/lib/registry/effective-limits.ts) | user override 持久化 + `getEffectiveLimit` + `useEffectiveLimit` hook |
+| [src/lib/registry/assemble-context.ts](src/lib/registry/assemble-context.ts) | 装配总闸 + 各 source budget 接入可调层 |
+| [src/lib/registry/context-sources.ts](src/lib/registry/context-sources.ts) | reader 类（foreshadows / storyArcs / stateCards）接入可调层 |
+| [src/lib/ai/context-builder.ts](src/lib/ai/context-builder.ts) | reader / formatter 类（locations / historical / character / storyCore / creativeRules）接入可调层 |
+| [src/lib/ai/codex-context.ts](src/lib/ai/codex-context.ts) | codex reader 接入可调层 |
+| [src/lib/ai/prompt-engine.ts](src/lib/ai/prompt-engine.ts) | few-shot 数量上限接入可调层 |
+| [src/lib/ai/adapters/chapter-adapter.ts](src/lib/ai/adapters/chapter-adapter.ts) | 续写 `existingContent.slice(-N)` 接入可调层 |
+| [src/components/shared/FieldLimitHint.tsx](src/components/shared/FieldLimitHint.tsx) | 通用字段截断提示组件 |
+| [src/components/shared/PromptInjectionInspectorModal.tsx](src/components/shared/PromptInjectionInspectorModal.tsx) | 「查看注入 prompt」Modal |
+| [src/components/settings/AdvancedSettingsPanel.tsx](src/components/settings/AdvancedSettingsPanel.tsx) | 「高级设置」子面板：开关 + 5 分组可调表格 + 全部恢复 |
+| [src/components/settings/SettingsPage.tsx](src/components/settings/SettingsPage.tsx) | 接入 `<AdvancedSettingsPanel />` |
+| [src/components/outline/OutlinePanel.tsx](src/components/outline/OutlinePanel.tsx) | 接入「查看注入 prompt」按钮（卷级 / 章节级） |
+| [src/components/editor/ChapterEditor.tsx](src/components/editor/ChapterEditor.tsx) | 接入「查看 prompt」按钮（生成 / 续写）+ 前一章结尾长度可调 |
+| [src/components/character/CharacterPanel.tsx](src/components/character/CharacterPanel.tsx) | 7 个角色字段加截断提示，并接入 `useEffectiveLimit` |
+| [src/components/rules/CreativeRulesPanel.tsx](src/components/rules/CreativeRulesPanel.tsx) | 3 个规则字段加截断提示，并接入 `useEffectiveLimit` |
+| [src/components/worldview/StoryCorePanel.tsx](src/components/worldview/StoryCorePanel.tsx) | 主线 / 复线截断提示接入 `useEffectiveLimit` |
+| [src/components/history/HistoryPanel.tsx](src/components/history/HistoryPanel.tsx) | 事件 / 关键词描述截断提示接入 `useEffectiveLimit` |
+
+---
+
 ## v3.4.0.1 — 2026-06-14 · 历史年表升级 · 考据 / 风暴双 agent 解耦 · 提示词模板化
 
 > 本次围绕"历史年表"做了一次系统性升级：把单 agent 的"AI 考证 / 头脑风暴"二选一拆成了**两个并行的 agent**，把作者输入拆成了**四块互不污染的文本窗**，并让两个 agent 的提示词正式进入**「提示词库」可见、可克隆、可复盘**——以前是一段写死在面板里的 system prompt。

--- a/docs/AI-FUNCTIONS-MANUAL.generated.md
+++ b/docs/AI-FUNCTIONS-MANUAL.generated.md
@@ -102,12 +102,12 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 | category | 触发文件 |
 |---|---|
 | `ai.restructure` | `src/lib/ai/restructure.ts:52` |
-| `chapter.content` | `src/components/editor/ChapterEditor.tsx:275` |
+| `chapter.content` | `src/components/editor/ChapterEditor.tsx:280` |
 | `chapter.content.batch` | `src/lib/ai/batch-detail-runner.ts:256` |
-| `chapter.continue` | `src/components/editor/ChapterEditor.tsx:283` |
-| `chapter.deai` | `src/components/editor/ChapterEditor.tsx:371` |
-| `chapter.expand` | `src/components/editor/ChapterEditor.tsx:363` |
-| `chapter.polish` | `src/components/editor/ChapterEditor.tsx:355` |
+| `chapter.continue` | `src/components/editor/ChapterEditor.tsx:289` |
+| `chapter.deai` | `src/components/editor/ChapterEditor.tsx:378` |
+| `chapter.expand` | `src/components/editor/ChapterEditor.tsx:370` |
+| `chapter.polish` | `src/components/editor/ChapterEditor.tsx:362` |
 | `chapter.toolbar` | `src/components/editor/FloatingToolbar.tsx:105` |
 | `character.generate` | `src/components/character/CharacterPanel.tsx:134` |
 | `character.structure` | `src/lib/ai/parse-character-output.ts:92` |
@@ -119,9 +119,9 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 | `geography.world-map` | `src/components/geography/WorldMapPanel.tsx:98` |
 | `inspiration.reverse` | `src/components/project/InspirationPanel.tsx:110` |
 | `inventory.extract` | `src/components/items/InventoryPanel.tsx:63` |
-| `outline.chapter` | `src/components/outline/OutlinePanel.tsx:231`<br/>`src/lib/ai/batch-outline-runner.ts:123` |
+| `outline.chapter` | `src/components/outline/OutlinePanel.tsx:256`<br/>`src/lib/ai/batch-outline-runner.ts:123` |
 | `outline.character-driven` | `src/components/outline/CharacterDrivenPlotPanel.tsx:115` |
-| `outline.volume` | `src/components/outline/OutlinePanel.tsx:216` |
+| `outline.volume` | `src/components/outline/OutlinePanel.tsx:241` |
 | `prompt.examples` | `src/components/settings/prompt/PromptExamplesEditor.tsx:105` |
 | `reference.characters` | `src/components/project/AnalysisReportViewer.tsx:138` |
 | `reference.summary` | `src/components/project/AnalysisReportViewer.tsx:109` |
@@ -147,4 +147,4 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 
 ---
 
-生成时间基准:commit `c13dba3`
+生成时间基准:commit `a67554b`

--- a/docs/AI-FUNCTIONS-MANUAL.generated.md
+++ b/docs/AI-FUNCTIONS-MANUAL.generated.md
@@ -102,14 +102,14 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 | category | 触发文件 |
 |---|---|
 | `ai.restructure` | `src/lib/ai/restructure.ts:52` |
-| `chapter.content` | `src/components/editor/ChapterEditor.tsx:272` |
+| `chapter.content` | `src/components/editor/ChapterEditor.tsx:275` |
 | `chapter.content.batch` | `src/lib/ai/batch-detail-runner.ts:256` |
-| `chapter.continue` | `src/components/editor/ChapterEditor.tsx:280` |
-| `chapter.deai` | `src/components/editor/ChapterEditor.tsx:304` |
-| `chapter.expand` | `src/components/editor/ChapterEditor.tsx:296` |
-| `chapter.polish` | `src/components/editor/ChapterEditor.tsx:288` |
+| `chapter.continue` | `src/components/editor/ChapterEditor.tsx:283` |
+| `chapter.deai` | `src/components/editor/ChapterEditor.tsx:371` |
+| `chapter.expand` | `src/components/editor/ChapterEditor.tsx:363` |
+| `chapter.polish` | `src/components/editor/ChapterEditor.tsx:355` |
 | `chapter.toolbar` | `src/components/editor/FloatingToolbar.tsx:105` |
-| `character.generate` | `src/components/character/CharacterPanel.tsx:132` |
+| `character.generate` | `src/components/character/CharacterPanel.tsx:134` |
 | `character.structure` | `src/lib/ai/parse-character-output.ts:92` |
 | `detail.scene` | `src/components/outline/DetailedOutlinePanel.tsx:163`<br/>`src/components/outline/ScenePanel.tsx:110`<br/>`src/lib/ai/batch-detail-runner.ts:109` |
 | `emotion.beat` | `src/components/editor/EmotionBeatCard.tsx:65` |
@@ -119,9 +119,9 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 | `geography.world-map` | `src/components/geography/WorldMapPanel.tsx:98` |
 | `inspiration.reverse` | `src/components/project/InspirationPanel.tsx:110` |
 | `inventory.extract` | `src/components/items/InventoryPanel.tsx:63` |
-| `outline.chapter` | `src/components/outline/OutlinePanel.tsx:224`<br/>`src/lib/ai/batch-outline-runner.ts:123` |
+| `outline.chapter` | `src/components/outline/OutlinePanel.tsx:231`<br/>`src/lib/ai/batch-outline-runner.ts:123` |
 | `outline.character-driven` | `src/components/outline/CharacterDrivenPlotPanel.tsx:115` |
-| `outline.volume` | `src/components/outline/OutlinePanel.tsx:209` |
+| `outline.volume` | `src/components/outline/OutlinePanel.tsx:216` |
 | `prompt.examples` | `src/components/settings/prompt/PromptExamplesEditor.tsx:105` |
 | `reference.characters` | `src/components/project/AnalysisReportViewer.tsx:138` |
 | `reference.summary` | `src/components/project/AnalysisReportViewer.tsx:109` |
@@ -129,10 +129,10 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 | `review.anti-ai` | `src/components/editor/ReviewPanel.tsx:57` |
 | `review.quality` | `src/components/editor/ReviewPanel.tsx:49` |
 | `review.readability` | `src/components/editor/ReviewPanel.tsx:66` |
-| `rules.generate` | `src/components/rules/CreativeRulesPanel.tsx:77` |
+| `rules.generate` | `src/components/rules/CreativeRulesPanel.tsx:84` |
 | `scene.verify` | `src/components/scene/SceneVerifyPanel.tsx:76` |
 | `story-arc.generate` | `src/components/outline/StoryArcPanel.tsx:83` |
-| `story.generate` | `src/components/worldview/StoryCorePanel.tsx:190` |
+| `story.generate` | `src/components/worldview/StoryCorePanel.tsx:196` |
 | `story.timeline` | `src/components/timeline/StoryTimelinePanel.tsx:70` |
 | `style.learn` | `src/components/style/StyleLearningPanel.tsx:76` |
 | `world-group.expand` | `src/components/world-group/WorldGroupDetail.tsx:97` |
@@ -147,4 +147,4 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 
 ---
 
-生成时间基准:commit `286a042`
+生成时间基准:commit `c13dba3`

--- a/src/components/character/CharacterPanel.tsx
+++ b/src/components/character/CharacterPanel.tsx
@@ -3,6 +3,8 @@ import {
   Plus, Sparkles, Trash2, ChevronDown, ChevronRight,
 } from 'lucide-react'
 import { InlineInput, InlineTextarea } from '../shared/InlineEdit'
+import FieldLimitHint from '../shared/FieldLimitHint'
+import { useEffectiveLimit } from '../../lib/registry/effective-limits'
 import { useCharacterStore } from '../../stores/character'
 import { useWorldGroupStore } from '../../stores/world-group'
 import { useAIConfigStore } from '../../stores/ai-config'
@@ -353,14 +355,26 @@ function CharacterDetailCard({
   const [expanded, setExpanded] = useState(true)
   const glyphColor = GLYPH_COLORS[charIndex % GLYPH_COLORS.length]
 
-  const fields: { key: keyof Character; label: string }[] = [
-    { key: 'appearance',   label: '外貌' },
-    { key: 'personality',  label: '性格' },
-    { key: 'background',   label: '背景故事' },
-    { key: 'motivation',   label: '动机' },
-    { key: 'abilities',    label: '能力' },
-    { key: 'relationships', label: '人物关系' },
-    { key: 'arc',          label: '角色弧' },
+  // H3 — 各字段在 buildCharacterContext 里的 slice 阈值。读 effective-limits，
+  // 与高级设置面板里写的覆盖值实时同步（仅主角 / 反派档位会注入这些字段，
+  // supporting 档位只注入 shortDescription + relationships，其余档位完全只剩名字）。
+  const limAppearance   = useEffectiveLimit('fmt.character.appearance', 150)
+  const limPersonality  = useEffectiveLimit('fmt.character.personality', 150)
+  const limBackground   = useEffectiveLimit('fmt.character.background', 200)
+  const limMotivation   = useEffectiveLimit('fmt.character.motivation', 150)
+  const limAbilities    = useEffectiveLimit('fmt.character.abilities', 150)
+  const limArc          = useEffectiveLimit('fmt.character.arc', 150)
+  const limRelationship = useEffectiveLimit('fmt.character.relationships', 80)
+
+  const fields: { key: keyof Character; label: string; limit?: number; note?: string }[] = [
+    { key: 'appearance',    label: '外貌',     limit: limAppearance,   note: '主角 / 反派档位会注入；超出会被截断。' },
+    { key: 'personality',   label: '性格',     limit: limPersonality,  note: '主角 / 反派档位会注入；超出会被截断。' },
+    { key: 'background',    label: '背景故事', limit: limBackground,   note: '主角 / 反派档位会注入；超出会被截断。' },
+    { key: 'motivation',    label: '动机',     limit: limMotivation,   note: '主角 / 反派档位会注入；超出会被截断。' },
+    { key: 'abilities',     label: '能力',     limit: limAbilities,    note: '主角 / 反派档位会注入；超出会被截断。' },
+    { key: 'relationships', label: '人物关系', limit: limRelationship,
+      note: '注意：仅在「重要配角」档位时注入 prompt 并按上述长度截断；主角 / 反派档位中此字段不会进入 AI 上下文。' },
+    { key: 'arc',           label: '角色弧',   limit: limArc,          note: '主角 / 反派档位会注入；超出会被截断。' },
   ]
 
   return (
@@ -468,6 +482,14 @@ function CharacterDetailCard({
                     onChange={v => onUpdate(f.key, v)}
                     placeholder={`点击填写${f.label}…`}
                   />
+                  {f.limit !== undefined && (
+                    <FieldLimitHint
+                      value={val}
+                      limit={f.limit}
+                      unit="chars"
+                      note={f.note}
+                    />
+                  )}
                 </div>
               </div>
             )

--- a/src/components/editor/ChapterEditor.tsx
+++ b/src/components/editor/ChapterEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
-import { Save, FileText, Eye, ClipboardList, CheckSquare, Square, BookOpenCheck, ShieldCheck, StickyNote } from 'lucide-react'
+import { Save, FileText, Eye, ClipboardList, CheckSquare, Square, BookOpenCheck, ShieldCheck, StickyNote, Search } from 'lucide-react'
 import { useChapterStore } from '../../stores/chapter'
 import { useOutlineStore } from '../../stores/outline'
 import { useStateCardStore } from '../../stores/state-card'
@@ -20,7 +20,7 @@ import { htmlToPlainText, plainTextToHtml, countWords } from '../../lib/utils/ht
 import AIStreamOutput from '../shared/AIStreamOutput'
 import ContextBudgetBar from '../shared/ContextBudgetBar'
 import { useAIConfigStore } from '../../stores/ai-config'
-import { analyzeContextSegments, calculateBudget, type ContextBudget } from '../../lib/ai/context-budget'
+import { analyzeContextSegments, calculateBudget, getModelPreset, type ContextBudget } from '../../lib/ai/context-budget'
 import StateDiffModal from '../state/StateDiffModal'
 import RichEditor, { type RichEditorHandle } from './RichEditor'
 import EmotionBeatCard from './EmotionBeatCard'
@@ -28,6 +28,9 @@ import OutlinePreview from '../outline/OutlinePreview'
 import ReviewPanel from './ReviewPanel'
 import NotePanel from './NotePanel'
 import FloatingToolbar from './FloatingToolbar'
+import PromptInjectionInspectorModal, { type InspectorPayload } from '../shared/PromptInjectionInspectorModal'
+import { useAdvancedMode } from '../../hooks/useAdvancedMode'
+import { getEffectiveLimit } from '../../lib/registry/effective-limits'
 import type { Project, StateDiffItem } from '../../lib/types'
 
 /** 生成任务类型(原 memory-builder 三层记忆已被 assembleContext 取代,此类型仅用于调试日志标签) */
@@ -247,7 +250,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
   const handleGenerate = async () => {
     if (!outlineNode) return
     const prevChapter = chapters.filter(c => c.order < (currentChapter?.order || 0)).pop()
-    const prevEnding = htmlToPlainText(prevChapter?.content || '').slice(-500)
+    const prevEnding = htmlToPlainText(prevChapter?.content || '').slice(-getEffectiveLimit('engine.previousEnding', 500))
     const { text: fullCtx, segments: assembledSegments, worldRulesContext } = await buildFullWorldCtx('write')
     const messages = buildChapterContentPrompt(
       outlineNode.title,
@@ -279,6 +282,70 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
     setAIAction('continue')
     ai.start(messages, undefined, { category: 'chapter.continue', projectId: project.id! })
   }
+
+  // ── H4 — 注入 prompt 预览（仅高级模式显示按钮 + Modal） ──
+  const [advancedMode] = useAdvancedMode()
+  const [inspectorOpen, setInspectorOpen] = useState<null | 'generate' | 'continue'>(null)
+
+  /** 与 handleGenerate / handleContinue 同口径地装配，再额外取一份 assembled 给 inspector 用。 */
+  const buildInspectorPayload = useCallback(async (kind: 'generate' | 'continue'): Promise<InspectorPayload | null> => {
+    if (!outlineNode) return null
+    if (kind === 'continue' && !plainText) return null
+
+    // 取与 buildFullWorldCtx 同套 sourceKeys 的 assembled 用于面板展示
+    let citedIds: number[] = []
+    try { citedIds = JSON.parse(creativeRules?.citedReferenceIds || '[]') } catch { /* ignore */ }
+    const stateRef = [
+      outlineNode?.title,
+      outlineNode?.summary,
+      currentChapter?.title,
+      plainText.slice(-2000),
+    ].filter(Boolean).join(' ')
+    const assembled = await assembleContext({
+      projectId: project.id!,
+      worldGroupId: chapterWorldGroupId ?? null,
+      outlineNodeId: outlineNode?.id ?? null,
+      chapterId: currentChapter?.id ?? null,
+      currentChapterOrder: currentChapter?.order ?? 0,
+      provider: aiConfig.provider,
+      model: aiConfig.model,
+      citedReferenceIds: citedIds,
+      stateReferenceText: stateRef,
+      extraStateIds,
+      sourceKeys: [
+        'contextMemo', 'chapterOutline', 'detailedOutline',
+        'worldview', 'storyCore', 'powerSystem', 'codex', 'characters',
+        'creativeRules', 'worldRules', 'historical', 'locations',
+        'foreshadows', 'storyArcs', 'emotionBeats', 'stateCards',
+        'references', 'userStyleProfile',
+      ],
+    })
+
+    // 复用 buildFullWorldCtx 拼出真实送给 AI 的 fullCtx（含 genre / style 注入），保证一致
+    const { text: fullCtx, worldRulesContext } = await buildFullWorldCtx('write')
+
+    let messages
+    if (kind === 'generate') {
+      const prevChapter = chapters.filter(c => c.order < (currentChapter?.order || 0)).pop()
+      const prevEnding = htmlToPlainText(prevChapter?.content || '').slice(-getEffectiveLimit('engine.previousEnding', 500))
+      messages = buildChapterContentPrompt(
+        outlineNode.title, outlineNode.summary, fullCtx, charCtx, prevEnding, worldRulesContext,
+      )
+    } else {
+      messages = buildContinuePrompt(plainText, outlineNode.summary, fullCtx)
+    }
+    const preset = getModelPreset(aiConfig.provider, aiConfig.model)
+    const modelMaxContext = (aiConfig.contextWindow && aiConfig.contextWindow > 0)
+      ? aiConfig.contextWindow
+      : preset.maxContext
+    return {
+      messages,
+      assembled,
+      category: kind === 'generate' ? '正文生成' : '正文续写',
+      modelMaxContext,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [outlineNode, currentChapter, plainText, chapters, chapterWorldGroupId, project.id, aiConfig.provider, aiConfig.model, aiConfig.contextWindow, charCtx, creativeRules, extraStateIds])
 
   const handlePolish = () => {
     const selected = editorRef.current?.getSelectedText() || plainText.slice(-1000)
@@ -549,6 +616,26 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
           className="px-3 py-1.5 bg-bg-elevated text-text-secondary text-xs rounded-md hover:text-text-primary disabled:opacity-50 transition-colors">
           📝 续写
         </button>
+        {advancedMode && (
+          <>
+            <button
+              onClick={() => setInspectorOpen('generate')}
+              disabled={!outlineNode}
+              title="查看本次「生成正文」会装入的所有上下文段、messages 与 token 占用"
+              className="flex items-center gap-1 px-3 py-1.5 bg-bg-elevated text-amber-400 text-xs rounded-md hover:bg-amber-500/10 border border-amber-500/30 disabled:opacity-50 transition-colors"
+            >
+              <Search className="w-3 h-3" /> 查看 prompt（生成）
+            </button>
+            <button
+              onClick={() => setInspectorOpen('continue')}
+              disabled={!outlineNode || !plainText}
+              title="查看本次「续写」会装入的所有上下文段、messages 与 token 占用"
+              className="flex items-center gap-1 px-3 py-1.5 bg-bg-elevated text-amber-400 text-xs rounded-md hover:bg-amber-500/10 border border-amber-500/30 disabled:opacity-50 transition-colors"
+            >
+              <Search className="w-3 h-3" /> 查看 prompt（续写）
+            </button>
+          </>
+        )}
         <button onClick={handleExpand} disabled={ai.isStreaming}
           className="px-3 py-1.5 bg-bg-elevated text-text-secondary text-xs rounded-md hover:text-text-primary disabled:opacity-50 transition-colors">
           📖 扩写
@@ -654,7 +741,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
           characterContext={charCtx}
           prevChapterEnding={(() => {
             const prev = chapters.filter(c => c.order < (currentChapter?.order || 0)).pop()
-            return htmlToPlainText(prev?.content || '').slice(-500)
+            return htmlToPlainText(prev?.content || '').slice(-getEffectiveLimit('engine.previousEnding', 500))
           })()}
         />
       )}
@@ -745,6 +832,13 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
           showSkip={autoProcessing !== 'idle'}
         />
       )}
+
+      {/* H4 — 注入 prompt 预览 Modal（仅高级模式开启时按钮才会触发） */}
+      <PromptInjectionInspectorModal
+        open={inspectorOpen != null}
+        buildPayload={() => inspectorOpen ? buildInspectorPayload(inspectorOpen) : null}
+        onClose={() => setInspectorOpen(null)}
+      />
     </div>
   )
 }

--- a/src/components/editor/ChapterEditor.tsx
+++ b/src/components/editor/ChapterEditor.tsx
@@ -252,6 +252,10 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
     const prevChapter = chapters.filter(c => c.order < (currentChapter?.order || 0)).pop()
     const prevEnding = htmlToPlainText(prevChapter?.content || '').slice(-getEffectiveLimit('engine.previousEnding', 500))
     const { text: fullCtx, segments: assembledSegments, worldRulesContext } = await buildFullWorldCtx('write')
+    // 把工具栏「自定义指令」输入框的内容注入 user prompt 模板的 {{userHint}} 槽位。
+    // adapter 早就支持 userHint，模板（chapter.content）也带 {{#if userHint}} 块；
+    // 此前只有 polish 接通这条路径，generate / continue / expand 都漏接，导致用户填的指令实际不进 prompt。
+    const userHint = customInstruction.trim() || undefined
     const messages = buildChapterContentPrompt(
       outlineNode.title,
       outlineNode.summary,
@@ -259,6 +263,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
       charCtx,
       prevEnding,
       worldRulesContext,
+      userHint,
     )
 
     // Phase 21.3: 计算上下文预算
@@ -278,7 +283,8 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
   const handleContinue = async () => {
     if (!plainText || !outlineNode) return
     const { text: fullCtx } = await buildFullWorldCtx('write')
-    const messages = buildContinuePrompt(plainText, outlineNode.summary, fullCtx)
+    const userHint = customInstruction.trim() || undefined
+    const messages = buildContinuePrompt(plainText, outlineNode.summary, fullCtx, userHint)
     setAIAction('continue')
     ai.start(messages, undefined, { category: 'chapter.continue', projectId: project.id! })
   }
@@ -330,9 +336,10 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
       const prevEnding = htmlToPlainText(prevChapter?.content || '').slice(-getEffectiveLimit('engine.previousEnding', 500))
       messages = buildChapterContentPrompt(
         outlineNode.title, outlineNode.summary, fullCtx, charCtx, prevEnding, worldRulesContext,
+        customInstruction.trim() || undefined,
       )
     } else {
-      messages = buildContinuePrompt(plainText, outlineNode.summary, fullCtx)
+      messages = buildContinuePrompt(plainText, outlineNode.summary, fullCtx, customInstruction.trim() || undefined)
     }
     const preset = getModelPreset(aiConfig.provider, aiConfig.model)
     const modelMaxContext = (aiConfig.contextWindow && aiConfig.contextWindow > 0)
@@ -345,7 +352,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
       modelMaxContext,
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [outlineNode, currentChapter, plainText, chapters, chapterWorldGroupId, project.id, aiConfig.provider, aiConfig.model, aiConfig.contextWindow, charCtx, creativeRules, extraStateIds])
+  }, [outlineNode, currentChapter, plainText, chapters, chapterWorldGroupId, project.id, aiConfig.provider, aiConfig.model, aiConfig.contextWindow, charCtx, creativeRules, extraStateIds, customInstruction])
 
   const handlePolish = () => {
     const selected = editorRef.current?.getSelectedText() || plainText.slice(-1000)
@@ -358,7 +365,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
   const handleExpand = () => {
     const selected = editorRef.current?.getSelectedText() || plainText.slice(-500)
     if (!selected) return
-    const messages = buildExpandPrompt(selected)
+    const messages = buildExpandPrompt(selected, customInstruction.trim() || undefined)
     setAIAction('expand')
     ai.start(messages, undefined, { category: 'chapter.expand', projectId: project.id! })
   }

--- a/src/components/history/HistoryPanel.tsx
+++ b/src/components/history/HistoryPanel.tsx
@@ -16,6 +16,8 @@ import type { Project, HistoricalTimelineEvent, HistoricalEra, HistoricalKeyword
 import { HISTORICAL_ERA_LABELS, KEYWORD_CATEGORY_LABELS } from '../../lib/types/history'
 import AIStreamOutput from '../shared/AIStreamOutput'
 import { useDialog } from '../shared/Dialog'
+import FieldLimitHint from '../shared/FieldLimitHint'
+import { useEffectiveLimit } from '../../lib/registry/effective-limits'
 
 interface Props {
   project: Project
@@ -92,6 +94,10 @@ export default function HistoryPanel({ project }: Props) {
   const consultAI = useAIStream()
   const stormAI = useAIStream()
   const { worldview, loadAll: loadWorldview } = useWorldviewStore()
+
+  // H3 — 历史年表 description 截断阈值（与 buildHistoricalContext 保持同步）
+  const limEventDesc = useEffectiveLimit('reader.historical.event描述', 80)
+  const limKeywordDesc = useEffectiveLimit('reader.historical.关键词描述', 40)
 
   // 多世界：让 worldview store 跟随当前世界标签，保证历史 AI 考证读到对的世界设定
   useEffect(() => {
@@ -662,6 +668,12 @@ export default function HistoryPanel({ project }: Props) {
                                 placeholder="作者打磨好的最终条目内容，将作为 AI 写作的历史背景注入。例如：『公元 712 年，李隆基即位为唐玄宗，开元之治始。』"
                                 className="w-full h-24 p-2 bg-bg-base border border-border rounded-lg text-xs text-text-primary resize-y focus:outline-none focus:border-accent"
                               />
+                              <FieldLimitHint
+                                value={evt.description}
+                                limit={limEventDesc}
+                                unit="chars"
+                                note="注入大纲 / 正文写作时，事件描述会按此长度截断；事件名称、时间、地理范围另算。"
+                              />
                             </div>
 
                             {/* 对剧情/世界的影响（属于条目定稿的语义补充，紧跟其后；放在 AI 工作区之上） */}
@@ -1106,6 +1118,12 @@ export default function HistoryPanel({ project }: Props) {
                               onChange={e => updateKeyword(kw.id!, { description: e.target.value })}
                               placeholder="作者打磨好的最终条目内容，将作为 AI 写作的历史细节注入。例如：『飞钱：唐宪宗时期出现的汇兑凭证，由邸店或商号代为兑付。』"
                               className="w-full h-24 p-2 bg-bg-base border border-border rounded-lg text-xs text-text-primary resize-y focus:outline-none focus:border-accent"
+                            />
+                            <FieldLimitHint
+                              value={kw.description}
+                              limit={limKeywordDesc}
+                              unit="chars"
+                              note="注入大纲 / 正文写作时，关键词描述会按此长度截断；关键词名、分类、时期另算。"
                             />
                           </div>
 

--- a/src/components/outline/OutlinePanel.tsx
+++ b/src/components/outline/OutlinePanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
-import { Plus, Trash2, Sparkles, ChevronRight, ChevronDown, Check, X, LayoutList, Layers, Loader2, GripVertical, CornerDownRight } from 'lucide-react'
+import { Plus, Trash2, Sparkles, ChevronRight, ChevronDown, Check, X, LayoutList, Layers, Loader2, GripVertical, CornerDownRight, Eye } from 'lucide-react'
 import { useOutlineStore } from '../../stores/outline'
 import { useDragReorder, type ItemDnD } from './useDragReorder'
 import { useWorldviewStore } from '../../stores/worldview'
@@ -23,6 +23,9 @@ import AutoResizeTextarea from '../shared/AutoResizeTextarea'
 import { CInput } from '../shared/CompositionInput'
 import { useDialog } from '../shared/Dialog'
 import { useToast } from '../shared/Toast'
+import PromptInjectionInspectorModal, { type InspectorPayload } from '../shared/PromptInjectionInspectorModal'
+import { useAdvancedMode } from '../../hooks/useAdvancedMode'
+import { getModelPreset } from '../../lib/ai/context-budget'
 import type { Project, StoryStructure } from '../../lib/types'
 import { STORY_STRUCTURES } from '../../lib/types/outline'
 
@@ -75,6 +78,10 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
   const [batchResult, setBatchResult] = useState<Map<number, ParsedChapter[]> | null>(null)
 
   const ai = useAIStream()
+
+  // H4 — 注入 prompt 预览（仅高级模式显示按钮 + Modal）
+  const [advancedMode] = useAdvancedMode()
+  const [inspectorOpen, setInspectorOpen] = useState<null | 'volume' | 'chapter'>(null)
 
   useEffect(() => { loadAll(project.id!) }, [project.id, loadAll])
 
@@ -223,6 +230,44 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     const messages = buildChapterOutlinePrompt(selectedVol.title, selectedVol.summary, worldCtx, prevSummary, hint, buildOpts(), charCtx, rulesCtx)
     ai.start(messages, undefined, { category: 'outline.chapter', projectId: project.id! })
   }
+
+  /** 装配预览 payload。装配口径与 handleAIVolumes / handleAIChapters 完全一致，避免漂移。 */
+  const buildInspectorPayload = useCallback(async (kind: 'volume' | 'chapter'): Promise<InspectorPayload | null> => {
+    if (kind === 'chapter' && !selectedVol) return null
+    const groupId = kind === 'volume' ? null : (selectedVol?.worldGroupId ?? null)
+    const nodeId = kind === 'volume' ? null : selectedVol?.id
+    const assembled = await buildOutlineAssembledContext(groupId, nodeId)
+    const worldCtx = assembled.text
+    const charCtx = contextPart(assembled, 'characters')
+    const rulesCtx = contextPart(assembled, 'worldRules')
+
+    let messages
+    if (kind === 'volume') {
+      const scCtx = storyCore
+        ? `主题：${storyCore.theme}\n冲突：${storyCore.centralConflict}\n主线：${storyCore.mainPlot || storyCore.storyLines || ''}${storyCore.subPlots ? `\n复线：${storyCore.subPlots}` : ''}`
+        : ''
+      messages = buildVolumeOutlinePrompt(
+        project.name, project.genre, worldCtx, scCtx, project.targetWordCount || 500000, hint, buildOpts(), charCtx, rulesCtx,
+      )
+    } else {
+      const volIdx = volumes.indexOf(selectedVol!)
+      const prevSummary = volIdx > 0 ? volumes[volIdx - 1].summary : ''
+      messages = buildChapterOutlinePrompt(
+        selectedVol!.title, selectedVol!.summary, worldCtx, prevSummary, hint, buildOpts(), charCtx, rulesCtx,
+      )
+    }
+    const preset = getModelPreset(aiConfig.provider, aiConfig.model)
+    const modelMaxContext = (aiConfig.contextWindow && aiConfig.contextWindow > 0)
+      ? aiConfig.contextWindow
+      : preset.maxContext
+    return {
+      messages,
+      assembled,
+      category: kind === 'volume' ? '卷级大纲' : '章节大纲展开',
+      modelMaxContext,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedVol, storyCore, project.name, project.genre, project.targetWordCount, hint, volumes, aiConfig.provider, aiConfig.model, aiConfig.contextWindow, parameterValues, systemOverride, userOverride])
 
   // ── D1: 批量生成 ──
 
@@ -428,6 +473,16 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
           className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-accent text-white rounded-md hover:bg-accent-hover disabled:opacity-50 transition-colors">
           <Sparkles className="w-3.5 h-3.5" /> AI 生成卷级大纲
         </button>
+        {advancedMode && (
+          <button
+            onClick={() => setInspectorOpen('volume')}
+            disabled={batchRunning}
+            title="查看本次「AI 生成卷级大纲」会装入的所有上下文段、messages 与 token 占用"
+            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-[11px] bg-bg-elevated text-amber-400 rounded-md hover:bg-amber-500/10 border border-amber-500/30 disabled:opacity-50 transition-colors"
+          >
+            <Eye className="w-3.5 h-3.5" /> 查看注入 prompt（卷级）
+          </button>
+        )}
         {volumes.length >= 2 && (
           <button onClick={handleBatchGenerate} disabled={ai.isStreaming || batchRunning}
             className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-bg-elevated text-accent rounded-md hover:bg-accent/10 border border-accent/30 disabled:opacity-50 transition-colors">
@@ -602,6 +657,15 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
                   className="flex items-center gap-1 px-2.5 py-1.5 text-xs bg-accent text-white rounded-md hover:bg-accent-hover disabled:opacity-50 transition-colors">
                   <Sparkles className="w-3.5 h-3.5" /> AI 生成章节
                 </button>
+                {advancedMode && (
+                  <button
+                    onClick={() => setInspectorOpen('chapter')}
+                    title="查看本次「AI 生成章节」会装入的所有上下文段、messages 与 token 占用"
+                    className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] bg-bg-elevated text-amber-400 rounded-md hover:bg-amber-500/10 border border-amber-500/30 transition-colors"
+                  >
+                    <Eye className="w-3.5 h-3.5" /> 查看 prompt
+                  </button>
+                )}
                 <button onClick={() => handleAddChapter()}
                   className="flex items-center gap-1 px-2.5 py-1.5 text-xs bg-bg-elevated text-text-secondary rounded-md hover:text-text-primary border border-border transition-colors">
                   <Plus className="w-3.5 h-3.5" /> 添加章节
@@ -708,6 +772,13 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
           </div>
         )}
       </div>
+
+      {/* H4 — 注入 prompt 预览 Modal（仅高级模式开启时按钮才会触发） */}
+      <PromptInjectionInspectorModal
+        open={inspectorOpen != null}
+        buildPayload={() => inspectorOpen ? buildInspectorPayload(inspectorOpen) : null}
+        onClose={() => setInspectorOpen(null)}
+      />
     </PanelLayout>
   )
 }

--- a/src/components/outline/OutlinePanel.tsx
+++ b/src/components/outline/OutlinePanel.tsx
@@ -201,6 +201,29 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     return idx >= 0 ? assembled.segments[idx]?.content ?? '' : ''
   }
 
+  /**
+   * 装配 assembled.text 的"剔除版"——把那些会通过专属槽位单独注入的 source（如 characters / worldRules）
+   * 从 worldContext 里去掉，避免与 {{characterContext}} / {{worldRulesContext}} 形成完全机械的重复。
+   *
+   * 背景：assembleContext 装配后的 text 把所有 included source 顺序拼接；OutlinePanel 又把 characters
+   * 和 worldRules 当作"重要内容靠近 prompt 末尾"的专属槽位再注入一次，导致 AI 收到的 prompt 里同样的角色 /
+   * 历史锚点连续出现两份（每份各 ≤ 数百字），token 翻倍，且容易让模型对"哪一份才是权威"产生困惑。
+   */
+  const buildWorldContextWithout = (assembled: AssembleContextResult, excludeKeys: string[]): string => {
+    const exclude = new Set(excludeKeys)
+    // 与 assembleContext 内部 text 拼接保持同格式（segments.map(s => s.content).join('\n\n')），
+    // 仅把命中 excludeKeys 的那些 source 抽出来。这样在 OutlinePanel 既有的"专属槽位"注入风格下
+    // 不会引入新的小标题。
+    const kept: string[] = []
+    assembled.included.forEach((key, idx) => {
+      if (exclude.has(key)) return
+      const seg = assembled.segments[idx]
+      if (!seg || !seg.content) return
+      kept.push(seg.content)
+    })
+    return kept.join('\n\n')
+  }
+
   // ── AI 生成 ──
 
   const handleAIVolumes = async () => {
@@ -208,7 +231,9 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     setPreviewVolumes(null)
     setPreviewChapters(null)
     const assembled = await buildOutlineAssembledContext(null)
-    const worldCtx = assembled.text
+    // 把 characters 和 worldRules 排出 worldContext，因为它们会通过 {{characterContext}} / {{worldRulesContext}}
+    // 专属槽位单独注入；如果 worldCtx 仍带这两段，AI 会收到两份完全相同的内容。
+    const worldCtx = buildWorldContextWithout(assembled, ['characters', 'worldRules'])
     const scCtx = storyCore ? `主题：${storyCore.theme}\n冲突：${storyCore.centralConflict}\n主线：${storyCore.mainPlot || storyCore.storyLines || ''}${storyCore.subPlots ? `\n复线：${storyCore.subPlots}` : ''}` : ''
     const charCtx = contextPart(assembled, 'characters')
     const rulesCtx = contextPart(assembled, 'worldRules')
@@ -222,7 +247,7 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     setPreviewVolumes(null)
     setPreviewChapters(null)
     const assembled = await buildOutlineAssembledContext(selectedVol.worldGroupId ?? null, selectedVol.id)
-    const worldCtx = assembled.text
+    const worldCtx = buildWorldContextWithout(assembled, ['characters', 'worldRules'])
     const volIdx = volumes.indexOf(selectedVol)
     const prevSummary = volIdx > 0 ? volumes[volIdx - 1].summary : ''
     const charCtx = contextPart(assembled, 'characters')
@@ -237,7 +262,9 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     const groupId = kind === 'volume' ? null : (selectedVol?.worldGroupId ?? null)
     const nodeId = kind === 'volume' ? null : selectedVol?.id
     const assembled = await buildOutlineAssembledContext(groupId, nodeId)
-    const worldCtx = assembled.text
+    // 与 handleAIVolumes / handleAIChapters 同口径：把 characters 和 worldRules 从 worldCtx 中剔除，
+    // 避免它们在专属槽位 + worldContext 双注入造成机械重复。
+    const worldCtx = buildWorldContextWithout(assembled, ['characters', 'worldRules'])
     const charCtx = contextPart(assembled, 'characters')
     const rulesCtx = contextPart(assembled, 'worldRules')
 
@@ -281,7 +308,7 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     batchAbortRef.current = controller
 
     const assembled = await buildOutlineAssembledContext(null)
-    const worldCtx = assembled.text
+    const worldCtx = buildWorldContextWithout(assembled, ['characters', 'worldRules'])
     const charCtx = contextPart(assembled, 'characters')
     const rulesCtx = contextPart(assembled, 'worldRules')
 
@@ -294,7 +321,7 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
           ? async (volId) => {
             const vol = nodes.find(n => n.id === volId)
             const resolved = await buildOutlineAssembledContext(vol?.worldGroupId ?? null, volId)
-            return resolved.text
+            return buildWorldContextWithout(resolved, ['characters', 'worldRules'])
           }
           : undefined,
         worldRulesContextResolver: project.enableMultiWorld

--- a/src/components/rules/CreativeRulesPanel.tsx
+++ b/src/components/rules/CreativeRulesPanel.tsx
@@ -8,6 +8,8 @@ import { useAIStream } from '../../hooks/useAIStream'
 import { buildRulesGeneratePrompt } from '../../lib/ai/adapters/rules-adapter'
 import { adopt } from '../../lib/registry/adopt'
 import AIStreamOutput from '../shared/AIStreamOutput'
+import FieldLimitHint from '../shared/FieldLimitHint'
+import { useEffectiveLimit } from '../../lib/registry/effective-limits'
 import type { Project, NarrativePOV } from '../../lib/types'
 
 const POV_OPTIONS: { value: NarrativePOV; label: string; desc: string }[] = [
@@ -35,6 +37,11 @@ export default function CreativeRulesPanel({ project }: Props) {
   const [citedRefIds, setCitedRefIds] = useState<number[]>([])
   const [aiTarget, setAiTarget] = useState<'writingStyle' | 'toneAndMood' | 'specialRequirements' | null>(null)
   const ai = useAIStream()
+
+  // H3 — 字段提示用 effective-limits，与高级设置实时同步
+  const limStyle = useEffectiveLimit('fmt.rules.style', 200)
+  const limAtmo = useEffectiveLimit('fmt.rules.atmosphere', 150)
+  const limSpecial = useEffectiveLimit('fmt.rules.special', 200)
 
   useEffect(() => {
     loadAll(project.id!)
@@ -203,6 +210,12 @@ export default function CreativeRulesPanel({ project }: Props) {
           placeholder="描述期望的写作风格，如：简洁凌厉、文笔华丽、幽默诙谐、冷峻写实..."
           className="w-full h-24 p-3 bg-bg-surface border border-border rounded-lg text-text-primary text-sm resize-y focus:outline-none focus:border-accent"
         />
+        <FieldLimitHint
+          value={writingStyle}
+          limit={limStyle}
+          unit="chars"
+          note="超出会被截断后再注入 AI 上下文。"
+        />
         {aiTarget === 'writingStyle' && (ai.output || ai.isStreaming || ai.error) && (
           <div className="mt-2">
             <AIStreamOutput
@@ -256,6 +269,12 @@ export default function CreativeRulesPanel({ project }: Props) {
           onBlur={() => saveField({ toneAndMood })}
           placeholder="描述作品的整体基调和氛围，如：黑暗压抑、热血激昂、温馨治愈..."
           className="w-full h-20 p-3 bg-bg-surface border border-border rounded-lg text-text-primary text-sm resize-y focus:outline-none focus:border-accent"
+        />
+        <FieldLimitHint
+          value={toneAndMood}
+          limit={limAtmo}
+          unit="chars"
+          note="超出会被截断后再注入 AI 上下文。"
         />
         {aiTarget === 'toneAndMood' && (ai.output || ai.isStreaming || ai.error) && (
           <div className="mt-2">
@@ -357,6 +376,12 @@ export default function CreativeRulesPanel({ project }: Props) {
           onBlur={() => saveField({ specialRequirements })}
           placeholder="其他需要 AI 遵守的特殊创作要求..."
           className="w-full h-24 p-3 bg-bg-surface border border-border rounded-lg text-text-primary text-sm resize-y focus:outline-none focus:border-accent"
+        />
+        <FieldLimitHint
+          value={specialRequirements}
+          limit={limSpecial}
+          unit="chars"
+          note="超出会被截断后再注入 AI 上下文。"
         />
         {aiTarget === 'specialRequirements' && (ai.output || ai.isStreaming || ai.error) && (
           <div className="mt-2">

--- a/src/components/settings/AdvancedSettingsPanel.tsx
+++ b/src/components/settings/AdvancedSettingsPanel.tsx
@@ -19,10 +19,12 @@ import {
   resetAllEffectiveLimits,
   onEffectiveLimitsChange,
 } from '../../lib/registry/effective-limits'
+import { useDialog } from '../shared/Dialog'
 
 export default function AdvancedSettingsPanel() {
   const [enabled, setEnabled] = useAdvancedMode()
   const [snapshot, setSnapshot] = useState<Record<string, number>>(() => getEffectiveLimitsSnapshot())
+  const dialog = useDialog()
 
   // 订阅 effective-limits 变化（写入 / 跨标签页 / 全部恢复）
   useEffect(() => {
@@ -100,10 +102,14 @@ export default function AdvancedSettingsPanel() {
             {overriddenCount > 0 && (
               <button
                 type="button"
-                onClick={() => {
-                  if (confirm(`确定恢复全部 ${overriddenCount} 项 budget 到默认值？`)) {
-                    resetAllEffectiveLimits()
-                  }
+                onClick={async () => {
+                  const ok = await dialog.confirm({
+                    title: '恢复全部默认值？',
+                    message: `确定恢复全部 ${overriddenCount} 项 budget 到默认值？`,
+                    confirmText: '全部恢复',
+                    tone: 'danger',
+                  })
+                  if (ok) resetAllEffectiveLimits()
                 }}
                 className="shrink-0 inline-flex items-center gap-1 px-2.5 py-1 text-xs bg-bg-base border border-amber-500/40 text-amber-400 rounded hover:bg-amber-500/10 transition-colors"
               >

--- a/src/components/settings/AdvancedSettingsPanel.tsx
+++ b/src/components/settings/AdvancedSettingsPanel.tsx
@@ -1,0 +1,233 @@
+/**
+ * 高级设置子面板（H2 暴露 → H5 调整入口）
+ *
+ * 行为：
+ * - 顶部「高级模式」开关（默认关闭）。OFF 时仅显示开关本身 + 说明文。
+ * - ON 后展示 5 个分组的 budget / 截断阈值表格。每行右侧是一个数字输入框，
+ *   作者填进去会立即覆盖运行时默认值；留空 / 点「恢复」则回退到 budget-config.ts 的默认值。
+ * - 整体「全部恢复默认」按钮在头部。
+ *
+ * 注意：H3 字段提示与超限警告不读高级模式开关，始终生效。本面板仅控制内部 budget。
+ */
+import { useEffect, useMemo, useState } from 'react'
+import { Lock, Unlock, Layers, Info, AlertTriangle, RotateCcw, Save, Check } from 'lucide-react'
+import { useAdvancedMode } from '../../hooks/useAdvancedMode'
+import { BUDGET_GROUPS, flattenBudgetEntry, type BudgetEntry, type BudgetLeaf } from '../../lib/registry/budget-config'
+import {
+  getEffectiveLimitsSnapshot,
+  setEffectiveLimit,
+  resetAllEffectiveLimits,
+  onEffectiveLimitsChange,
+} from '../../lib/registry/effective-limits'
+
+export default function AdvancedSettingsPanel() {
+  const [enabled, setEnabled] = useAdvancedMode()
+  const [snapshot, setSnapshot] = useState<Record<string, number>>(() => getEffectiveLimitsSnapshot())
+
+  // 订阅 effective-limits 变化（写入 / 跨标签页 / 全部恢复）
+  useEffect(() => {
+    return onEffectiveLimitsChange(() => setSnapshot(getEffectiveLimitsSnapshot()))
+  }, [])
+
+  // 把所有 entry 拍平成 leaf，方便整体「全部恢复」时知道有哪些被改过
+  const allLeafs = useMemo(() => {
+    const out: BudgetLeaf[] = []
+    for (const g of BUDGET_GROUPS) for (const e of g.entries) out.push(...flattenBudgetEntry(e))
+    return out
+  }, [])
+  const overriddenCount = allLeafs.filter(l => snapshot[l.flatKey] !== undefined).length
+
+  return (
+    <div className="max-w-3xl mt-6 p-4 bg-bg-surface border border-border rounded-xl">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-text-primary flex items-center gap-1.5">
+            {enabled
+              ? <Unlock className="w-4 h-4 text-amber-500" />
+              : <Lock className="w-4 h-4 text-text-muted" />}
+            高级设置
+            {enabled && overriddenCount > 0 && (
+              <span className="text-[10px] text-amber-400 font-normal">
+                · 已覆盖 {overriddenCount} 项默认值
+              </span>
+            )}
+          </h3>
+          <p className="text-xs text-text-muted mt-1 leading-relaxed">
+            打开后会暴露上下文装配的 budget、各上下文源的 token 上限、Reader 与字段格式化层的硬截断阈值，
+            并解锁后续步骤里的「查看注入 prompt」「调整截断长度」等高级入口。
+            <span className="text-amber-500"> 这些内部参数普通使用不需要关心；改动会直接影响 AI 调用的 token 消耗。</span>
+          </p>
+          <p className="text-xs text-text-muted mt-1">
+            提示：业务面板上的字段「文本提示」与「超限警告」始终对所有用户可见，<span className="text-text-secondary">不受此开关影响</span>。
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setEnabled(!enabled)}
+          aria-pressed={enabled}
+          className={`relative inline-flex shrink-0 h-6 w-11 items-center rounded-full transition-colors ${
+            enabled ? 'bg-amber-500' : 'bg-bg-elevated border border-border'
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              enabled ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* 高级模式开关 OFF：到此为止，避免信息过载 */}
+      {!enabled && (
+        <div className="mt-4 p-3 bg-bg-base border border-border/60 rounded-lg flex items-start gap-2 text-xs text-text-muted">
+          <Info className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span>开关处于关闭状态。打开后才会显示 budget 表格与后续高级控件。</span>
+        </div>
+      )}
+
+      {/* 高级模式 ON：暴露所有 budget / 截断阈值（可调） */}
+      {enabled && (
+        <div className="mt-5 space-y-5">
+          <div className="p-3 bg-amber-500/5 border border-amber-500/30 rounded-lg flex items-start gap-2 text-xs text-amber-200/90">
+            <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0 text-amber-500" />
+            <div className="flex-1 leading-relaxed">
+              <p className="text-amber-400 font-medium">下方为内部预算与硬截断阈值（可调整）</p>
+              <p className="mt-1">
+                数值默认取自源代码事实清单 <code className="px-1 py-0.5 bg-bg-base rounded">src/lib/registry/budget-config.ts</code>。
+                在右侧输入新值会立即覆盖运行时；点「↺」单项恢复，或下方「全部恢复默认」一次清空。
+              </p>
+            </div>
+            {overriddenCount > 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  if (confirm(`确定恢复全部 ${overriddenCount} 项 budget 到默认值？`)) {
+                    resetAllEffectiveLimits()
+                  }
+                }}
+                className="shrink-0 inline-flex items-center gap-1 px-2.5 py-1 text-xs bg-bg-base border border-amber-500/40 text-amber-400 rounded hover:bg-amber-500/10 transition-colors"
+              >
+                <RotateCcw className="w-3 h-3" /> 全部恢复默认
+              </button>
+            )}
+          </div>
+
+          {BUDGET_GROUPS.map(group => (
+            <section key={group.id} className="space-y-2">
+              <header>
+                <h4 className="text-sm font-medium text-text-primary flex items-center gap-1.5">
+                  <Layers className="w-3.5 h-3.5 text-amber-500" />
+                  {group.label}
+                  <span className="text-[10px] text-text-muted font-normal">
+                    （{group.entries.length} 项）
+                  </span>
+                </h4>
+                <p className="text-[11px] text-text-muted mt-0.5">{group.description}</p>
+              </header>
+
+              <div className="overflow-x-auto rounded-lg border border-border">
+                <table className="min-w-full text-xs">
+                  <thead className="bg-bg-elevated">
+                    <tr className="text-left text-[10px] text-text-muted uppercase">
+                      <th className="px-3 py-1.5 font-normal">字段</th>
+                      <th className="px-3 py-1.5 font-normal">默认值</th>
+                      <th className="px-3 py-1.5 font-normal">单位</th>
+                      <th className="px-3 py-1.5 font-normal w-44">当前生效</th>
+                      <th className="px-3 py-1.5 font-normal">说明</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {group.entries.flatMap(e => flattenBudgetEntry(e)).map(leaf => (
+                      <BudgetRow key={leaf.flatKey} leaf={leaf} snapshot={snapshot} />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BudgetRow({ leaf, snapshot }: { leaf: BudgetLeaf; snapshot: Record<string, number> }) {
+  const overridden = snapshot[leaf.flatKey] !== undefined
+  const effective = overridden ? snapshot[leaf.flatKey] : leaf.defaultValue
+  const [draft, setDraft] = useState<string>(String(effective))
+  const [savedFlash, setSavedFlash] = useState(false)
+
+  // 外部变化（如 全部恢复）时同步本地 input 值
+  useEffect(() => { setDraft(String(effective)) }, [effective])
+
+  const commit = () => {
+    const trimmed = draft.trim()
+    if (trimmed === '') {
+      setEffectiveLimit(leaf.flatKey, null) // 视为恢复默认
+      return
+    }
+    const num = Number(trimmed)
+    if (!Number.isFinite(num) || num <= 0) {
+      // 输入非法：还原为当前生效值
+      setDraft(String(effective))
+      return
+    }
+    if (Math.round(num) === leaf.defaultValue) {
+      setEffectiveLimit(leaf.flatKey, null) // 显式回到默认值时清掉 override
+      return
+    }
+    setEffectiveLimit(leaf.flatKey, Math.round(num))
+    setSavedFlash(true)
+    setTimeout(() => setSavedFlash(false), 1200)
+  }
+
+  const reset = () => setEffectiveLimit(leaf.flatKey, null)
+
+  const parent: BudgetEntry = leaf.parent
+
+  return (
+    <tr className="border-t border-border/60">
+      <td className="px-3 py-2 text-text-primary">{leaf.label}</td>
+      <td className="px-3 py-2 font-mono text-text-muted whitespace-nowrap">{leaf.defaultValue.toLocaleString()}</td>
+      <td className="px-3 py-2 text-text-muted">{parent.unit}</td>
+      <td className="px-3 py-2 whitespace-nowrap">
+        <div className="flex items-center gap-1">
+          <input
+            type="number"
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={e => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+            min={1}
+            className={`w-24 px-2 py-1 bg-bg-base border rounded text-xs font-mono focus:outline-none focus:border-amber-500 ${
+              overridden ? 'border-amber-500/60 text-amber-400' : 'border-border text-text-primary'
+            }`}
+          />
+          {overridden ? (
+            <button
+              type="button"
+              onClick={reset}
+              title="恢复此项默认值"
+              className="p-1 text-text-muted hover:text-amber-400 hover:bg-bg-hover rounded transition-colors"
+            >
+              <RotateCcw className="w-3 h-3" />
+            </button>
+          ) : (
+            <span className="w-5 inline-block" />
+          )}
+          {savedFlash && (
+            <span className="inline-flex items-center gap-0.5 text-[10px] text-green-400">
+              <Check className="w-3 h-3" /> 已保存
+            </span>
+          )}
+          {!savedFlash && overridden && !draft.startsWith('—') && (
+            <span className="inline-flex items-center gap-0.5 text-[10px] text-amber-400">
+              <Save className="w-3 h-3" /> 覆盖中
+            </span>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-2 text-text-secondary leading-relaxed">{parent.note}</td>
+    </tr>
+  )
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { BookOpen } from 'lucide-react'
 import AIConfigPanel from './AIConfigPanel'
+import AdvancedSettingsPanel from './AdvancedSettingsPanel'
 import { resetWelcomeGuide } from '../guide/WelcomeGuide'
 
 /**
@@ -14,6 +15,9 @@ export default function SettingsPage() {
   return (
     <div className="h-full overflow-auto p-6">
       <AIConfigPanel />
+
+      {/* H2 — 高级设置子面板：默认折叠隐藏；开关打开后暴露 budget / 截断阈值 */}
+      <AdvancedSettingsPanel />
 
       {/* 其他设置 */}
       <div className="max-w-2xl mt-6 p-4 bg-bg-surface border border-border rounded-xl">

--- a/src/components/shared/FieldLimitHint.tsx
+++ b/src/components/shared/FieldLimitHint.tsx
@@ -1,0 +1,75 @@
+/**
+ * FieldLimitHint（H3 — 硬截断阈值文本提示 + 超限警告）
+ *
+ * 两条要点（按 H2 阶段中确立的需求）：
+ * 1. 始终显示一行灰底文本提示，告诉作者"该字段截断阈值是 N 字"。
+ * 2. 当输入字符数超过阈值，警告升级为琥珀色（含 AlertTriangle 图标 + 实际超出字数）。
+ *    但绝不阻断输入；作者仍可继续敲字 / 粘贴长文本。
+ *
+ * 该组件 **不读 useAdvancedMode**——按需求，无论是否进入高级模式，提示和警告都对所有
+ * 用户始终可见。这样普通用户也能感知到硬截断的存在，避免出现"我都填了为什么 AI 写得没用上"的困惑。
+ *
+ * 用法：把它放在 <CTextarea /> 后面，单独占一行：
+ *   <CTextarea value={x} onChange={...} />
+ *   <FieldLimitHint value={x} limit={250} unit="chars" note="超出会被截断，不进 AI 上下文。" />
+ */
+import { AlertTriangle, Info } from 'lucide-react'
+
+interface FieldLimitHintProps {
+  /** 当前字段值（用于计算长度）。 */
+  value: string
+  /** 截断阈值。 */
+  limit: number
+  /** 计量单位：chars = 字符；token = 估算 token。默认 chars。 */
+  unit?: 'chars' | 'token'
+  /** 自定义说明文本，会附加在阈值之后。例如"超出会被截断，不进 AI 上下文。" */
+  note?: string
+  /** 自定义类名（可选，覆盖默认间距） */
+  className?: string
+}
+
+/** 中文 ≈ 1.5 token/字，与 context-budget.ts 估算口径一致 */
+function estimateTokens(text: string): number {
+  if (!text) return 0
+  const cjkCount = (text.match(/[一-鿿㐀-䶿]/g) || []).length
+  const otherLen = text.length - cjkCount
+  return Math.round(cjkCount * 1.5 + otherLen * 0.25)
+}
+
+export default function FieldLimitHint({
+  value,
+  limit,
+  unit = 'chars',
+  note,
+  className = 'mt-1',
+}: FieldLimitHintProps) {
+  const measured = unit === 'token' ? estimateTokens(value || '') : (value || '').length
+  const over = measured > limit
+  const overBy = over ? measured - limit : 0
+  const unitLabel = unit === 'token' ? 'token' : '字'
+
+  if (over) {
+    return (
+      <div className={`flex items-start gap-1.5 text-[11px] text-amber-400 ${className}`}>
+        <AlertTriangle className="w-3 h-3 mt-0.5 shrink-0" />
+        <span>
+          当前 <span className="font-mono">{measured}</span> {unitLabel}，已超出截断阈值
+          （<span className="font-mono">{limit}</span> {unitLabel}）{' '}
+          <span className="font-mono">{overBy}</span> {unitLabel}；
+          <span className="text-amber-300/80">超出部分不会进入 AI 上下文。</span>
+          {note && <span className="text-text-muted ml-1">{note}</span>}
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`flex items-start gap-1.5 text-[11px] text-text-muted ${className}`}>
+      <Info className="w-3 h-3 mt-0.5 shrink-0" />
+      <span>
+        截断阈值：<span className="font-mono">{limit}</span> {unitLabel}（当前{' '}
+        <span className="font-mono">{measured}</span>）。{note}
+      </span>
+    </div>
+  )
+}

--- a/src/components/shared/PromptInjectionInspectorModal.tsx
+++ b/src/components/shared/PromptInjectionInspectorModal.tsx
@@ -1,0 +1,309 @@
+/**
+ * PromptInjectionInspectorModal（H4 — 大纲 / 正文「查看注入 prompt」）
+ *
+ * 设计：
+ * - 仅高级模式开启时由父组件渲染本 Modal（按钮也只在高级模式下显示）。
+ * - 父组件传入一个 builder：把当前面板真实使用的 `messages` 与 `assembled` 装配结果一并返回；
+ *   Modal 自己不去重新装配，避免与生产链路出现"看到的不是真的发出的"漂移。
+ *
+ * 展示三层信息：
+ *   ① assembleContext 装配后的每段 segment（label / layer / 字符 / token 估算 / 来源 source key）；
+ *   ② messages 数组（system / user 各自占用 token）；
+ *   ③ 总计：input token / 模型上限 / 是否超 assembleContext 总闸（`overBudgetBeforeTrim`）/
+ *      被裁剪的层（`trimmed`）/ 被排除的源（`omitted`）。
+ */
+import { useEffect, useState } from 'react'
+import { X, Layers, FileText, AlertTriangle, ChevronDown, ChevronRight, Copy, Check } from 'lucide-react'
+import { estimateTokens, formatTokenCount } from '../../lib/ai/context-budget'
+import type { AssembleContextResult } from '../../lib/registry/types'
+import type { ChatMessage } from '../../lib/types'
+
+export interface InspectorPayload {
+  /** 真实送给 AI 的 messages */
+  messages: ChatMessage[]
+  /** assembleContext 返回结果（如有） */
+  assembled?: AssembleContextResult | null
+  /** 调用入口的标签（如「卷级大纲」「章节正文」），仅展示用 */
+  category: string
+  /** 模型上限 token（可选；用于侧栏显示窗口比例） */
+  modelMaxContext?: number
+}
+
+interface Props {
+  open: boolean
+  /** 父组件按需调用、按需返回 */
+  buildPayload: () => Promise<InspectorPayload | null> | InspectorPayload | null
+  onClose: () => void
+}
+
+export default function PromptInjectionInspectorModal({ open, buildPayload, onClose }: Props) {
+  const [payload, setPayload] = useState<InspectorPayload | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    setPayload(null)
+    Promise.resolve()
+      .then(buildPayload)
+      .then(p => {
+        if (cancelled) return
+        if (!p) setError('当前没有可用的 prompt 装配结果（可能字段没填、章节未选中等）。')
+        else setPayload(p)
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err))
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+    // buildPayload 可能由父组件内联生成；只在 open 切换 true 时触发，避免父组件 re-render 抖动。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col bg-bg-base border border-border rounded-xl shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* 头部 */}
+        <header className="flex items-center justify-between px-5 py-3 border-b border-border bg-bg-surface">
+          <div>
+            <h2 className="text-sm font-semibold text-text-primary flex items-center gap-1.5">
+              <Layers className="w-4 h-4 text-amber-500" />
+              注入 prompt 预览
+              {payload && <span className="text-xs text-text-muted font-normal">· {payload.category}</span>}
+            </h2>
+            <p className="text-[11px] text-text-muted mt-0.5">
+              展示当前点击「生成」按钮时实际会发送给 AI 的全部上下文段、messages 与各段 token 占用。
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 text-text-muted hover:text-text-primary hover:bg-bg-hover rounded transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </header>
+
+        {/* 主体 */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-5 text-xs">
+          {loading && <div className="text-text-muted">正在装配 prompt…</div>}
+          {error && (
+            <div className="p-3 rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 text-xs flex items-start gap-2">
+              <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {payload && (
+            <>
+              <SummaryBar payload={payload} />
+              <SegmentsTable payload={payload} />
+              <MessagesPreview payload={payload} />
+            </>
+          )}
+        </div>
+
+        {/* 底部 */}
+        <footer className="px-5 py-2 border-t border-border bg-bg-surface flex items-center justify-end gap-2">
+          <span className="text-[10px] text-text-muted mr-auto">
+            数据基于 assembleContext 装配后再加上各 adapter 拼装的 user / system，与真实发出的 prompt 一致。
+          </span>
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs bg-bg-elevated text-text-secondary rounded hover:bg-bg-hover transition-colors"
+          >
+            关闭
+          </button>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function SummaryBar({ payload }: { payload: InspectorPayload }) {
+  const { messages, assembled, modelMaxContext } = payload
+  const messagesTokens = messages.reduce((sum, m) => sum + estimateTokens(m.content), 0)
+  const overAssemble = !!assembled?.overBudgetBeforeTrim
+  const ratio = modelMaxContext ? messagesTokens / modelMaxContext : null
+
+  return (
+    <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      <Stat label="message 总 token" value={formatTokenCount(messagesTokens)} valueClass="text-amber-400" />
+      <Stat
+        label="assembleContext 总闸"
+        value={assembled ? `${formatTokenCount(assembled.totalInputTokens)} / ${formatTokenCount(assembled.inputBudget)}` : '—'}
+        valueClass={overAssemble ? 'text-amber-400' : 'text-text-primary'}
+        hint={overAssemble ? '装配前已超总闸，按 L3→L2→L1 已裁剪。' : undefined}
+      />
+      <Stat
+        label="模型窗口占比"
+        value={ratio != null ? `${(ratio * 100).toFixed(1)}%` : '—'}
+        valueClass={ratio != null && ratio > 0.85 ? 'text-amber-400' : 'text-text-primary'}
+        hint={modelMaxContext ? `模型窗口 ${formatTokenCount(modelMaxContext)} token` : undefined}
+      />
+      <Stat
+        label="message 数"
+        value={String(messages.length)}
+        valueClass="text-text-primary"
+        hint={`system: ${messages.filter(m => m.role === 'system').length} / user: ${messages.filter(m => m.role === 'user').length}`}
+      />
+    </section>
+  )
+}
+
+function Stat({ label, value, valueClass, hint }: { label: string; value: string; valueClass?: string; hint?: string }) {
+  return (
+    <div className="p-3 bg-bg-surface border border-border rounded-lg">
+      <div className="text-[10px] text-text-muted uppercase tracking-wide">{label}</div>
+      <div className={`text-base font-mono mt-0.5 ${valueClass ?? 'text-text-primary'}`}>{value}</div>
+      {hint && <div className="text-[10px] text-text-muted mt-0.5">{hint}</div>}
+    </div>
+  )
+}
+
+function SegmentsTable({ payload }: { payload: InspectorPayload }) {
+  const a = payload.assembled
+  if (!a) {
+    return (
+      <section className="p-3 bg-bg-surface border border-border rounded-lg text-text-muted">
+        本次调用未通过 assembleContext 装配（或装配结果未传入），仅展示 messages。
+      </section>
+    )
+  }
+  return (
+    <section className="space-y-2">
+      <header className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-text-primary flex items-center gap-1.5">
+          <Layers className="w-3.5 h-3.5 text-amber-500" />
+          上下文段（assembleContext）
+          <span className="text-[10px] text-text-muted font-normal">已装入 {a.included.length} 段</span>
+        </h3>
+        <div className="text-[10px] text-text-muted">
+          {a.trimmed.length > 0 && <span className="text-amber-400">已裁剪：{a.trimmed.join(' / ')}</span>}
+          {a.trimmed.length > 0 && a.omitted.length > 0 && <span className="mx-1">·</span>}
+          {a.omitted.length > 0 && <span>未启用：{a.omitted.length} 个 source</span>}
+        </div>
+      </header>
+
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="min-w-full">
+          <thead className="bg-bg-elevated">
+            <tr className="text-left text-[10px] text-text-muted uppercase">
+              <th className="px-3 py-1.5 font-normal">段</th>
+              <th className="px-3 py-1.5 font-normal">层级</th>
+              <th className="px-3 py-1.5 font-normal">字符</th>
+              <th className="px-3 py-1.5 font-normal">token（估算）</th>
+              <th className="px-3 py-1.5 font-normal">截断标记</th>
+            </tr>
+          </thead>
+          <tbody>
+            {a.segments.map((seg, i) => {
+              const truncated = seg.content.includes('（该上下文源已按预算截断）')
+              return (
+                <tr key={i} className="border-t border-border/60">
+                  <td className="px-3 py-1.5 text-text-primary">{seg.label}</td>
+                  <td className="px-3 py-1.5 text-text-muted font-mono">{seg.layer}</td>
+                  <td className="px-3 py-1.5 text-text-muted font-mono">{seg.content.length.toLocaleString()}</td>
+                  <td className="px-3 py-1.5 font-mono text-amber-400">{formatTokenCount(seg.tokens)}</td>
+                  <td className="px-3 py-1.5">
+                    {truncated
+                      ? <span className="text-amber-400 text-[10px]">已按 source 预算截断</span>
+                      : <span className="text-text-muted text-[10px]">—</span>}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {a.omitted.length > 0 && (
+        <div className="text-[10px] text-text-muted">
+          未启用 source（缺前置条件 / 字段为空 / enabled() 返回 false）：
+          <span className="font-mono ml-1">{a.omitted.join(' / ')}</span>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function MessagesPreview({ payload }: { payload: InspectorPayload }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-medium text-text-primary flex items-center gap-1.5">
+        <FileText className="w-3.5 h-3.5 text-amber-500" />
+        Messages（最终发送给 AI）
+      </h3>
+      {payload.messages.map((m, i) => (
+        <CollapsibleMessage key={i} index={i} message={m} />
+      ))}
+    </section>
+  )
+}
+
+function CollapsibleMessage({ index, message }: { index: number; message: ChatMessage }) {
+  const [open, setOpen] = useState(message.role === 'user')
+  const [copied, setCopied] = useState(false)
+  const tokens = estimateTokens(message.content)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const roleColor =
+    message.role === 'system' ? 'text-blue-400 border-blue-400/30 bg-blue-500/5' :
+    message.role === 'user'   ? 'text-purple-400 border-purple-400/30 bg-purple-500/5' :
+    'text-text-secondary border-border bg-bg-surface'
+
+  return (
+    <div className={`rounded-lg border ${roleColor.split(' ').slice(1).join(' ')}`}>
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="w-full flex items-center justify-between px-3 py-2 text-left"
+      >
+        <span className={`text-[10px] font-medium uppercase tracking-wide ${roleColor.split(' ')[0]}`}>
+          {open ? <ChevronDown className="w-3 h-3 inline mr-1" /> : <ChevronRight className="w-3 h-3 inline mr-1" />}
+          message #{index + 1} · {message.role}
+        </span>
+        <span className="text-[10px] text-text-muted font-mono">
+          {message.content.length.toLocaleString()} 字 · {formatTokenCount(tokens)} token
+        </span>
+      </button>
+      {open && (
+        <div className="px-3 pb-3 space-y-2">
+          <div className="flex items-center justify-end">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="text-[10px] text-text-muted hover:text-text-primary flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-bg-hover transition-colors"
+            >
+              {copied
+                ? <><Check className="w-3 h-3 text-green-400" /> 已复制</>
+                : <><Copy className="w-3 h-3" /> 复制</>}
+            </button>
+          </div>
+          <pre className="whitespace-pre-wrap break-words text-[11px] text-text-secondary bg-bg-base border border-border/60 rounded p-2 max-h-64 overflow-y-auto">
+            {message.content}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/worldview/StoryCorePanel.tsx
+++ b/src/components/worldview/StoryCorePanel.tsx
@@ -7,6 +7,8 @@ import { buildStoryGeneratePrompt } from '../../lib/ai/adapters/story-adapter'
 import AIStreamOutput from '../shared/AIStreamOutput'
 import PromptRunPanel from '../shared/PromptRunPanel'
 import { InlineTextarea } from '../shared/InlineEdit'
+import FieldLimitHint from '../shared/FieldLimitHint'
+import { useEffectiveLimit } from '../../lib/registry/effective-limits'
 import AIFieldModeTabs from '../shared/AIFieldModeTabs'
 import type { Project } from '../../lib/types'
 import type { FieldGenerationMode } from '../../lib/ai/field-generation-context'
@@ -171,6 +173,10 @@ function FieldEditor({
   const [mode, setMode] = useState<FieldGenerationMode>('expand')
   const ai = useAIStream()
 
+  // H3 — 硬截断阈值，读 effective-limits（与高级设置实时同步）
+  const limMainPlot = useEffectiveLimit('fmt.storyCore.mainPlot', 250)
+  const limSubPlots = useEffectiveLimit('fmt.storyCore.subPlots', 200)
+
   // 通知父组件 streaming 状态
   useEffect(() => {
     onStreamingChange(ai.isStreaming)
@@ -208,6 +214,24 @@ function FieldEditor({
           placeholder={`点击填写${field.label}…`}
         />
       </div>
+
+      {/* H3 — 硬截断阈值提示（仅 mainPlot/subPlots 在 formatStoryCoreBlock 里有显式 slice） */}
+      {field.key === 'mainPlot' && (
+        <FieldLimitHint
+          value={value}
+          limit={limMainPlot}
+          unit="chars"
+          note="超出会被截断后再注入 AI 上下文。"
+        />
+      )}
+      {field.key === 'subPlots' && (
+        <FieldLimitHint
+          value={value}
+          limit={limSubPlots}
+          unit="chars"
+          note="超出会被截断后再注入 AI 上下文。"
+        />
+      )}
 
       {/* AI 生成区 */}
       <div className="space-y-3">

--- a/src/hooks/useAdvancedMode.ts
+++ b/src/hooks/useAdvancedMode.ts
@@ -1,0 +1,71 @@
+/**
+ * 高级模式开关（H2.0 — 暴露 budget / 截断阈值之前的总闸）
+ *
+ * 设计目标：
+ * - 默认关闭，避免普通用户面对一长串内部参数。
+ * - 持久化在 localStorage，跨页面 / 刷新保留。
+ * - 跨组件订阅同一份状态：在「高级设置」面板切换后，其他面板（例如未来要加的
+ *   「查看注入 prompt」按钮）能实时响应。
+ *
+ * 注意：硬截断阈值在各业务面板上的「文本提示」与「超限警告」并不依赖此开关，
+ * 它们始终对所有用户可见（参见 H3 步骤）。本开关只控制：
+ *   - 设置 → 高级设置 子面板里的 budget 集中展示；
+ *   - 大纲 / 正文生成面板上的「查看注入 prompt」按钮（H4）；
+ *   - 高级设置子面板里的 budget / 截断长度调整入口（H5）。
+ */
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'storyforge.advancedMode'
+const EVENT_NAME = 'storyforge:advanced-mode-change'
+
+function readInitial(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+/** 同步读取（非 React 上下文也可用，例如 SettingsPage 之外的工具函数）。 */
+export function isAdvancedModeEnabled(): boolean {
+  return readInitial()
+}
+
+/** 写入新值并广播同窗口事件（跨标签页则依赖原生 storage 事件）。 */
+export function setAdvancedModeEnabled(next: boolean): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, next ? '1' : '0')
+  } catch {
+    /* localStorage 满 / 隐私模式 → 静默失败，本次会话仍可用内存值 */
+  }
+  window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: next }))
+}
+
+/** React 组件用的订阅 hook。 */
+export function useAdvancedMode(): [boolean, (next: boolean) => void] {
+  const [enabled, setEnabled] = useState<boolean>(readInitial)
+
+  useEffect(() => {
+    const onCustom = (e: Event) => {
+      const ce = e as CustomEvent<boolean>
+      setEnabled(!!ce.detail)
+    }
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setEnabled(e.newValue === '1')
+    }
+    window.addEventListener(EVENT_NAME, onCustom)
+    window.addEventListener('storage', onStorage)
+    return () => {
+      window.removeEventListener(EVENT_NAME, onCustom)
+      window.removeEventListener('storage', onStorage)
+    }
+  }, [])
+
+  const setter = (next: boolean) => {
+    setAdvancedModeEnabled(next)
+    setEnabled(next) // 当前组件立即生效（不等事件 round-trip）
+  }
+  return [enabled, setter]
+}

--- a/src/lib/ai/adapters/chapter-adapter.ts
+++ b/src/lib/ai/adapters/chapter-adapter.ts
@@ -1,6 +1,7 @@
 import type { ChatMessage } from '../../types'
 import { usePromptStore } from '../../../stores/prompt'
 import { renderPrompt } from '../prompt-engine'
+import { getEffectiveLimit } from '../../registry/effective-limits'
 
 export interface RunOptions {
   parameterValues?: Record<string, unknown>
@@ -38,10 +39,12 @@ export function buildContinuePrompt(
   options?: RunOptions,
 ): ChatMessage[] {
   const tpl = usePromptStore.getState().getActive('chapter.continue')
+  // H5 — 续写时取已有正文末尾的字符数可调
+  const tailChars = getEffectiveLimit('engine.continueTail', 3000)
   const { messages } = renderPrompt(tpl, {
     chapterSummary,
     worldContext: worldContext || '（暂无）',
-    existingContent: existingContent.slice(-3000),
+    existingContent: existingContent.slice(-tailChars),
     userHint,
   }, options)
   return messages

--- a/src/lib/ai/codex-context.ts
+++ b/src/lib/ai/codex-context.ts
@@ -14,6 +14,7 @@ import {
   parseEntryFields, parseFieldSchema,
   type CodexCategory, type CodexEntry,
 } from '../types/codex'
+import { getEffectiveLimit } from '../registry/effective-limits'
 
 interface BuildOptions {
   /** 总长度预算（字符），默认 2500 */
@@ -33,9 +34,10 @@ export async function buildCodexContext(
   worldGroupId?: number | null,
   opts: BuildOptions = {},
 ): Promise<string> {
-  const maxChars = opts.maxChars ?? 2500
-  const maxPerCategory = opts.maxPerCategory ?? 30
-  const maxFields = opts.maxFieldsPerEntry ?? 3
+  // H5 — 可调阈值（opts 显式传入时优先于「高级设置」覆盖）
+  const maxChars = opts.maxChars ?? getEffectiveLimit('reader.codex.总字符上限', 2500)
+  const maxPerCategory = opts.maxPerCategory ?? getEffectiveLimit('reader.codex.每分类最多', 30)
+  const maxFields = opts.maxFieldsPerEntry ?? getEffectiveLimit('reader.codex.每条字段数', 3)
 
   const [allCats, allEntries] = await Promise.all([
     db.codexCategories.where('projectId').equals(projectId).toArray(),

--- a/src/lib/ai/context-builder.ts
+++ b/src/lib/ai/context-builder.ts
@@ -4,6 +4,7 @@ import { KEYWORD_CATEGORY_LABELS } from '../types/history'
 import { DIMENSION_LABELS, ANALYSIS_DIMENSIONS } from '../types/reference'
 import { loadContextMemo } from '../export/context-snapshot'
 import { db } from '../db/schema'
+import { getEffectiveLimit } from '../registry/effective-limits'
 
 /** 获取已缓存的上下文快照（如果有） */
 export function getContextMemo(projectId: number): string {
@@ -23,13 +24,17 @@ const POV_LABELS: Record<string, string> = {
  */
 export function buildCreativeRulesContext(rules: CreativeRules | null): string {
   if (!rules) return ''
+  // H5 — 可调阈值
+  const styleChars = getEffectiveLimit('fmt.rules.style', 200)
+  const atmoChars = getEffectiveLimit('fmt.rules.atmosphere', 150)
+  const specialChars = getEffectiveLimit('fmt.rules.special', 200)
   const parts: string[] = []
-  if (rules.writingStyle) parts.push(`写作风格：${rules.writingStyle.slice(0, 200)}`)
+  if (rules.writingStyle) parts.push(`写作风格：${rules.writingStyle.slice(0, styleChars)}`)
   const pov = rules.narrativePOV
   if (pov) parts.push(`叙事视角：${POV_LABELS[pov] || pov}`)
   const atmosphere = rules.atmosphere || rules.toneAndMood
-  if (atmosphere) parts.push(`基调氛围：${atmosphere.slice(0, 150)}`)
-  if (rules.specialRequirements) parts.push(`特殊要求：${rules.specialRequirements.slice(0, 200)}`)
+  if (atmosphere) parts.push(`基调氛围：${atmosphere.slice(0, atmoChars)}`)
+  if (rules.specialRequirements) parts.push(`特殊要求：${rules.specialRequirements.slice(0, specialChars)}`)
   try {
     const proh: string[] = JSON.parse(rules.prohibitions || '[]')
     if (proh.length) parts.push(`禁止事项：${proh.join('；').slice(0, 200)}`)
@@ -100,13 +105,16 @@ export function formatWorldviewBlock(wv: Worldview | null): string {
 /** 格式化故事核心为【故事核心】块（全字段）。 */
 export function formatStoryCoreBlock(sc: StoryCore | null): string {
   if (!sc) return ''
+  // H5 — 可调阈值
+  const mainPlotChars = getEffectiveLimit('fmt.storyCore.mainPlot', 250)
+  const subPlotsChars = getEffectiveLimit('fmt.storyCore.subPlots', 200)
   const parts = [
     sc.logline && `一句话故事：${sc.logline}`,
     sc.theme && `主题：${sc.theme}`,
     sc.centralConflict && `核心冲突：${sc.centralConflict}`,
     sc.plotPattern && `情节模式：${sc.plotPattern}`,
-    (sc.mainPlot || sc.storyLines) && `主线：${(sc.mainPlot || sc.storyLines).slice(0, 250)}`,
-    sc.subPlots && `复线：${sc.subPlots.slice(0, 200)}`,
+    (sc.mainPlot || sc.storyLines) && `主线：${(sc.mainPlot || sc.storyLines).slice(0, mainPlotChars)}`,
+    sc.subPlots && `复线：${sc.subPlots.slice(0, subPlotsChars)}`,
   ].filter(Boolean)
   return parts.length ? `【故事核心】\n${parts.join('\n')}` : ''
 }
@@ -179,6 +187,15 @@ export function buildWorldContext(wv: Worldview | null, sc: StoryCore | null, ps
 export function buildCharacterContext(characters: Character[]): string {
   if (!characters.length) return ''
 
+  // H5 — 可调阈值
+  const appearanceChars = getEffectiveLimit('fmt.character.appearance', 150)
+  const personalityChars = getEffectiveLimit('fmt.character.personality', 150)
+  const backgroundChars = getEffectiveLimit('fmt.character.background', 200)
+  const motivationChars = getEffectiveLimit('fmt.character.motivation', 150)
+  const abilitiesChars = getEffectiveLimit('fmt.character.abilities', 150)
+  const arcChars = getEffectiveLimit('fmt.character.arc', 150)
+  const relChars = getEffectiveLimit('fmt.character.relationships', 80)
+
   const core = characters.filter(c => c.role === 'protagonist' || c.role === 'antagonist')
   const supporting = characters.filter(c => c.role === 'supporting')
   const others = characters.filter(c => c.role !== 'protagonist' && c.role !== 'antagonist' && c.role !== 'supporting')
@@ -191,12 +208,12 @@ export function buildCharacterContext(characters: Character[]): string {
       const details = [
         `${c.name}（${getRoleLabel(c.role)}）`,
         c.shortDescription ? `简介：${c.shortDescription}` : '',
-        c.appearance ? `外貌：${c.appearance.slice(0, 150)}` : '',
-        c.personality ? `性格：${c.personality.slice(0, 150)}` : '',
-        c.background ? `背景：${c.background.slice(0, 200)}` : '',
-        c.motivation ? `动机：${c.motivation.slice(0, 150)}` : '',
-        c.abilities ? `能力：${c.abilities.slice(0, 150)}` : '',
-        c.arc ? `成长弧线：${c.arc.slice(0, 150)}` : '',
+        c.appearance ? `外貌：${c.appearance.slice(0, appearanceChars)}` : '',
+        c.personality ? `性格：${c.personality.slice(0, personalityChars)}` : '',
+        c.background ? `背景：${c.background.slice(0, backgroundChars)}` : '',
+        c.motivation ? `动机：${c.motivation.slice(0, motivationChars)}` : '',
+        c.abilities ? `能力：${c.abilities.slice(0, abilitiesChars)}` : '',
+        c.arc ? `成长弧线：${c.arc.slice(0, arcChars)}` : '',
       ].filter(Boolean).join('；')
       parts.push(details)
     }
@@ -205,7 +222,7 @@ export function buildCharacterContext(characters: Character[]): string {
   if (supporting.length) {
     parts.push('【重要配角（一句话+关系）】')
     for (const c of supporting) {
-      parts.push(`${c.name}：${c.shortDescription || '（无描述）'}${c.relationships ? `，关系：${c.relationships.slice(0, 80)}` : ''}`)
+      parts.push(`${c.name}：${c.shortDescription || '（无描述）'}${c.relationships ? `，关系：${c.relationships.slice(0, relChars)}` : ''}`)
     }
   }
 
@@ -293,7 +310,10 @@ export async function buildRefAnalysisContext(refIds: number[]): Promise<string>
  * Token 预算控制：最多 2000 字（约上下文窗口的 10%）。
  */
 export async function buildHistoricalContext(projectId: number, worldGroupId?: number | null): Promise<string> {
-  const MAX_CHARS = 2000
+  // H5 — 可调阈值（注意 reader.historical 整体字符上限）
+  const MAX_CHARS = getEffectiveLimit('reader.historical', 2000)
+  const eventDescChars = getEffectiveLimit('reader.historical.event描述', 80)
+  const keywordDescChars = getEffectiveLimit('reader.historical.关键词描述', 40)
   const parts: string[] = []
   let charCount = 0
   const project = await db.projects.get(projectId)
@@ -311,7 +331,7 @@ export async function buildHistoricalContext(projectId: number, worldGroupId?: n
     const eventLines: string[] = ['【历史时间线】']
     for (const e of events) {
       const marker = e.isHistorical ? '📜史实' : '✨虚构'
-      const line = `- ${e.date}（${marker}）：${e.title}${e.description ? `——${e.description.slice(0, 80)}` : ''}`
+      const line = `- ${e.date}（${marker}）：${e.title}${e.description ? `——${e.description.slice(0, eventDescChars)}` : ''}`
       if (charCount + line.length > MAX_CHARS * 0.6) break // 事件最多占 60%
       eventLines.push(line)
       charCount += line.length
@@ -338,7 +358,7 @@ export async function buildHistoricalContext(projectId: number, worldGroupId?: n
     for (const [cat, kws] of byCategory) {
       const label = KEYWORD_CATEGORY_LABELS[cat] || cat
       const items = kws.map(k => {
-        const desc = k.description ? `（${k.description.slice(0, 40)}）` : ''
+        const desc = k.description ? `（${k.description.slice(0, keywordDescChars)}）` : ''
         return `${k.keyword}${desc}`
       }).join('、')
       const line = `· ${label}：${items}`
@@ -363,11 +383,14 @@ export async function buildHistoricalContext(projectId: number, worldGroupId?: n
 export async function buildLocationContext(projectId: number): Promise<string> {
   const locs = await db.importantLocations.where('projectId').equals(projectId).toArray()
   if (!locs.length) return ''
-  const sorted = locs.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0)).slice(0, 25)
+  // H5 — 可调阈值
+  const maxItems = getEffectiveLimit('reader.locations.最多条数', 25)
+  const totalChars = getEffectiveLimit('reader.locations.总字符上限', 1200)
+  const sorted = locs.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0)).slice(0, maxItems)
   const lines = sorted.map(l => {
     const sig = l.significance ? `（${l.significance.slice(0, 50)}）` : ''
     const desc = l.description ? `：${l.description.slice(0, 60)}` : ''
     return `- ${l.name}${sig}${desc}`
   })
-  return `【重要地点】\n${lines.join('\n')}`.slice(0, 1200)
+  return `【重要地点】\n${lines.join('\n')}`.slice(0, totalChars)
 }

--- a/src/lib/ai/prompt-engine.ts
+++ b/src/lib/ai/prompt-engine.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage } from '../types'
 import type { PromptTemplate, PromptVariableContext } from '../types'
+import { getEffectiveLimit } from '../registry/effective-limits'
 
 /**
  * 渲染提示词模板。
@@ -62,8 +63,11 @@ export function renderPrompt(
   // P15: 拼接示例（few-shot）到 user prompt 末尾
   // - good 示例：作者标记的"输出风格参考"
   // - bad 示例：作者标记的"避免的输出"
-  const goodExamples = (template.examples?.good || []).filter(e => e.text.trim()).slice(0, 3)
-  const badExamples = (template.examples?.bad || []).filter(e => e.text.trim()).slice(0, 2)
+  // H5 — 数量上限可调
+  const goodMax = getEffectiveLimit('engine.fewShot.good', 3)
+  const badMax = getEffectiveLimit('engine.fewShot.bad', 2)
+  const goodExamples = (template.examples?.good || []).filter(e => e.text.trim()).slice(0, goodMax)
+  const badExamples = (template.examples?.bad || []).filter(e => e.text.trim()).slice(0, badMax)
   if (goodExamples.length > 0 || badExamples.length > 0) {
     const parts: string[] = ['', '---', '【参考示例】']
     if (goodExamples.length > 0) {

--- a/src/lib/registry/assemble-context.ts
+++ b/src/lib/registry/assemble-context.ts
@@ -5,6 +5,7 @@
  */
 import { estimateTokens, type ContextLayer, type ContextSegment } from '../ai/context-budget'
 import { CONTEXT_SOURCES, CONTEXT_SOURCE_BY_KEY } from './context-sources'
+import { getEffectiveLimit } from './effective-limits'
 import type { AssembleContextInput, AssembleContextResult, ContextSource } from './types'
 
 const DEFAULT_INPUT_BUDGET = 24_000
@@ -29,7 +30,9 @@ export async function assembleContext(input: AssembleContextInput): Promise<Asse
       omitted.push(source.key)
       continue
     }
-    const capped = capBySourceBudget(content, source.budgetTokens)
+    // H5：source 自身的 budgetTokens 允许在「高级设置」覆盖。key 形如 'src.contextMemo'
+    const effectiveBudget = getEffectiveLimit(`src.${source.key}`, source.budgetTokens)
+    const capped = capBySourceBudget(content, effectiveBudget)
     keyedSegments.push({
       key: source.key,
       segment: {
@@ -43,7 +46,9 @@ export async function assembleContext(input: AssembleContextInput): Promise<Asse
   }
 
   const totalBeforeTrim = keyedSegments.reduce((sum, s) => sum + s.segment.tokens, 0)
-  const inputBudget = input.inputBudgetTokens ?? DEFAULT_INPUT_BUDGET
+  // H5：assemble 总闸允许覆盖。
+  const inputBudget = input.inputBudgetTokens
+    ?? getEffectiveLimit('assemble.defaultInputBudget', DEFAULT_INPUT_BUDGET)
   const overBudgetBeforeTrim = totalBeforeTrim > inputBudget
   const { kept, trimmed } = trimToFit(keyedSegments, inputBudget)
   const segments = kept.map(s => s.segment)

--- a/src/lib/registry/budget-config.ts
+++ b/src/lib/registry/budget-config.ts
@@ -1,0 +1,160 @@
+/**
+ * Budget / 硬截断 阈值清单（H2 暴露阶段 — 单点查询事实源）
+ *
+ * 现状：项目里的 budget / 硬截断分散在多个文件：
+ *   - context-sources.ts 的 budgetTokens（每个 source 的 token 上限）
+ *   - assemble-context.ts 的 DEFAULT_INPUT_BUDGET（assembleContext 总闸）
+ *   - 各 reader / formatter 的 slice(0, N)、slice(0, M) 等"条数 / 字数"硬截断
+ *
+ * 本文件 **不修改任何运行时行为**，只把事实集中起来供：
+ *   1. 高级设置面板（H2）按表格只读展示；
+ *   2. 各业务面板的"超限提示与警告"（H3）查找各字段对应的字符上限；
+ *   3. 大纲 / 正文「查看注入 prompt」面板（H4）显示每段实际占用 vs 上限；
+ *   4. 高级设置面板的"调整入口"（H5）写回时定位字段。
+ *
+ * 维护原则：
+ * - 每条记录的 `value` 必须与代码里实际生效的写死值保持一致；改代码时同步改这里。
+ * - `targetCode` 只是供面板展示用的"出处"链接文本，不参与运行。
+ */
+
+/** 单条 budget 元数据 */
+export interface BudgetEntry {
+  /** 唯一键，用于 H5 调整入口写回时定位 */
+  key: string
+  /** 面板上展示的中文标签 */
+  label: string
+  /** 单位（token / chars / count） */
+  unit: 'token' | 'chars' | 'count'
+  /** 当前生效的硬编码数值；若为对象表示同一处有多种维度（如条数 + 单条字数） */
+  value: number | Record<string, number>
+  /** 简要说明：作者看到这个数值会立即知道它影响什么 */
+  note: string
+  /** 出处文件路径（仅展示用）*/
+  targetCode: string
+  /** 分组：context-source | assemble | reader | formatter | engine */
+  group: 'context-source' | 'assemble' | 'reader' | 'formatter' | 'engine'
+}
+
+/** Context source 级别的 token 上限（来自 context-sources.ts 各 source 的 budgetTokens） */
+export const CONTEXT_SOURCE_BUDGETS: BudgetEntry[] = [
+  { key: 'src.contextMemo',        label: '上下文快照',       unit: 'token', value: 1500, note: '装入 assembleContext 时的 token 硬上限。',                                  targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.chapterOutline',     label: '当前章节大纲',     unit: 'token', value: 800,  note: '当前章节的标题 + 摘要，注入正文写作。',                                      targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.detailedOutline',    label: '本章细纲（场景拆解）', unit: 'token', value: 1500, note: '逐场景拆解信息，注入正文写作。',                                            targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.previousChapterEnding', label: '上一章结尾',     unit: 'token', value: 500,  note: '正文写作时由调用方手动传入。',                                                targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.worldview',          label: '世界观',          unit: 'token', value: 2500, note: '世界观全字段格式化后的 token 上限。',                                          targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.storyCore',          label: '故事核心',         unit: 'token', value: 1200, note: 'logline / 主题 / 冲突 / 主线 / 复线 等。',                                    targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.powerSystem',        label: '力量体系',         unit: 'token', value: 1200, note: '力量体系名称 + 等级阶梯 + 规则。',                                            targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.codex',              label: '设定词条',         unit: 'token', value: 2500, note: '所有词条按分类紧凑序列化后的 token 上限。',                                  targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.characters',         label: '角色档案',         unit: 'token', value: 2500, note: '主角 + 重要配角 + 其他角色（分档处理）。',                                    targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.creativeRules',      label: '创作规则',         unit: 'token', value: 1000, note: '风格 / 视角 / 基调 / 禁忌 / 一致性等。',                                       targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.worldRules',         label: '真实与幻想规则',   unit: 'token', value: 1200, note: '世界规则清单。',                                                            targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.historical',         label: '历史时间线 / 关键词', unit: 'token', value: 1800, note: '历史年表 + 关键词条目（条目定稿）。',                                        targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.locations',          label: '重要地点',         unit: 'token', value: 1200, note: '按 sortOrder 取前若干条。',                                                  targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.foreshadows',        label: '伏笔',            unit: 'token', value: 1200, note: '当前章节关联的伏笔；无章节时取前若干条。',                                    targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.storyArcs',          label: '故事线（StoryArc）', unit: 'token', value: 1500, note: '主线 / 支线阶段卡。',                                                       targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.emotionBeats',       label: '情感节拍',         unit: 'token', value: 1000, note: '当前章节的整体弧线 + 节拍清单。',                                              targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.stateCards',         label: '状态卡',          unit: 'token', value: 1800, note: '按引用文本 / 手动勾选过滤后的状态卡列表。',                                  targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.references',         label: '引用手法',         unit: 'token', value: 2000, note: '已分析的参考作品的方法论结论。',                                              targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+  { key: 'src.userStyleProfile',   label: '我的文风',         unit: 'token', value: 700,  note: '作者文风画像（启用时）。',                                                  targetCode: 'src/lib/registry/context-sources.ts', group: 'context-source' },
+]
+
+/** assembleContext 全局总闸 */
+export const ASSEMBLE_BUDGETS: BudgetEntry[] = [
+  { key: 'assemble.defaultInputBudget', label: 'assembleContext 总闸', unit: 'token', value: 24000,
+    note: 'assembleContext 装配后总 token 上限。超出按 L3 → L2 → L1 整层裁剪。',
+    targetCode: 'src/lib/registry/assemble-context.ts', group: 'assemble' },
+]
+
+/** Reader 级别的"条数 + 单条字符"硬截断（写死在 reader 函数里的 slice(0, N)） */
+export const READER_BUDGETS: BudgetEntry[] = [
+  { key: 'reader.foreshadows',  label: '伏笔（无章节时）',   unit: 'count', value: { 最多条数: 25, 单条字符: 120 },
+    note: '无 chapterId 时取最近 25 条未结束伏笔，每条描述截 120 字。',
+    targetCode: 'src/lib/registry/context-sources.ts → readForeshadows', group: 'reader' },
+  { key: 'reader.storyArcs',    label: '故事线 storyArcs',   unit: 'count', value: { 最多故事线: 8, 每条阶段数: 6, 描述字符: 120, 阶段字符: 120 },
+    note: '故事线最多 8 条，每条阶段最多 6 个；描述与阶段各截 120 字。',
+    targetCode: 'src/lib/registry/context-sources.ts → readStoryArcs', group: 'reader' },
+  { key: 'reader.stateCards',   label: '状态卡',            unit: 'count', value: { 无引用文本时: 40, 每卡字段数: 8 },
+    note: '无引用文本时取前 40 张状态卡；每卡 fields 取前 8 个。',
+    targetCode: 'src/lib/registry/context-sources.ts → readStateCards', group: 'reader' },
+  { key: 'reader.locations',    label: '重要地点',          unit: 'count', value: { 最多条数: 25, 总字符上限: 1200 },
+    note: '按 sortOrder 取前 25 条；整段输出截 1200 字。',
+    targetCode: 'src/lib/ai/context-builder.ts → buildLocationContext', group: 'reader' },
+  { key: 'reader.historical',   label: '历史时间线 + 关键词', unit: 'chars', value: 2000,
+    note: '事件 + 关键词整体字符上限（其中事件最多占 60%）。',
+    targetCode: 'src/lib/ai/context-builder.ts → buildHistoricalContext', group: 'reader' },
+  { key: 'reader.historical.event描述',    label: '历史事件 · 描述截断',  unit: 'chars', value: 80,
+    note: '每条事件的 description 在注入大纲 / 正文 prompt 时按此长度截断（事件标题 / 时间 / 地理范围另算）。',
+    targetCode: 'src/lib/ai/context-builder.ts → buildHistoricalContext', group: 'reader' },
+  { key: 'reader.historical.关键词描述',   label: '历史关键词 · 描述截断', unit: 'chars', value: 40,
+    note: '每条历史关键词的 description 在注入 prompt 时按此长度截断（关键词名 / 分类 / 时期另算）。',
+    targetCode: 'src/lib/ai/context-builder.ts → buildHistoricalContext', group: 'reader' },
+  { key: 'reader.codex',        label: '设定词条',          unit: 'count', value: { 每分类最多: 30, 每条字段数: 3, 总字符上限: 2500 },
+    note: '词条按分类排版；超过总上限会被尾部截断。',
+    targetCode: 'src/lib/ai/codex-context.ts → buildCodexContext', group: 'reader' },
+]
+
+/** Formatter 级别的字段 slice 上限（context-builder 里的 .slice(0, N)） */
+export const FORMATTER_BUDGETS: BudgetEntry[] = [
+  { key: 'fmt.storyCore.mainPlot',     label: '故事核心 · 主线',  unit: 'chars', value: 250, note: '故事核心的"主线"字段，超出截 250 字。', targetCode: 'src/lib/ai/context-builder.ts → formatStoryCoreBlock', group: 'formatter' },
+  { key: 'fmt.storyCore.subPlots',     label: '故事核心 · 复线',  unit: 'chars', value: 200, note: '故事核心的"复线"字段，超出截 200 字。', targetCode: 'src/lib/ai/context-builder.ts → formatStoryCoreBlock', group: 'formatter' },
+  { key: 'fmt.character.appearance',   label: '角色 · 外貌',     unit: 'chars', value: 150, note: '主角 / 反派档位。', targetCode: 'src/lib/ai/context-builder.ts → buildCharacterContext', group: 'formatter' },
+  { key: 'fmt.character.personality',  label: '角色 · 性格',     unit: 'chars', value: 150, note: '主角 / 反派档位。', targetCode: 'src/lib/ai/context-builder.ts → buildCharacterContext', group: 'formatter' },
+  { key: 'fmt.character.background',   label: '角色 · 背景',     unit: 'chars', value: 200, note: '主角 / 反派档位。', targetCode: 'src/lib/ai/context-builder.ts → buildCharacterContext', group: 'formatter' },
+  { key: 'fmt.character.motivation',   label: '角色 · 动机',     unit: 'chars', value: 150, note: '主角 / 反派档位。', targetCode: 'src/lib/ai/context-builder.ts → buildCharacterContext', group: 'formatter' },
+  { key: 'fmt.character.abilities',    label: '角色 · 能力',     unit: 'chars', value: 150, note: '主角 / 反派档位。', targetCode: 'src/lib/ai/context-builder.ts → buildCharacterContext', group: 'formatter' },
+  { key: 'fmt.character.arc',          label: '角色 · 成长弧线', unit: 'chars', value: 150, note: '主角 / 反派档位。', targetCode: 'src/lib/ai/context-builder.ts → buildCharacterContext', group: 'formatter' },
+  { key: 'fmt.character.relationships',label: '配角 · 一句话关系', unit: 'chars', value: 80,  note: 'supporting 档位才注入；主 / 反派档位中此字段不进 prompt。', targetCode: 'src/lib/ai/context-builder.ts → buildCharacterContext', group: 'formatter' },
+  { key: 'fmt.rules.style',            label: '创作规则 · 写作风格', unit: 'chars', value: 200, note: '——', targetCode: 'src/lib/ai/context-builder.ts → buildCreativeRulesContext', group: 'formatter' },
+  { key: 'fmt.rules.atmosphere',       label: '创作规则 · 基调氛围', unit: 'chars', value: 150, note: '——', targetCode: 'src/lib/ai/context-builder.ts → buildCreativeRulesContext', group: 'formatter' },
+  { key: 'fmt.rules.special',          label: '创作规则 · 特殊要求', unit: 'chars', value: 200, note: '——', targetCode: 'src/lib/ai/context-builder.ts → buildCreativeRulesContext', group: 'formatter' },
+  { key: 'fmt.worldview.summary',      label: '世界观 · 摘要',    unit: 'chars', value: 300, note: 'formatWorldviewBlock 中各字段还有更细粒度的截断，详见原文件。', targetCode: 'src/lib/ai/context-builder.ts → formatWorldviewBlock', group: 'formatter' },
+]
+
+/** Engine 级别（few-shot / 续写裁剪等） */
+export const ENGINE_BUDGETS: BudgetEntry[] = [
+  { key: 'engine.fewShot.good',     label: 'few-shot 好示例上限', unit: 'count', value: 3,
+    note: '拼到 user prompt 末尾的好示例最多 3 条。', targetCode: 'src/lib/ai/prompt-engine.ts → renderPrompt', group: 'engine' },
+  { key: 'engine.fewShot.bad',      label: 'few-shot 反例上限',   unit: 'count', value: 2,
+    note: '拼到 user prompt 末尾的反例最多 2 条。', targetCode: 'src/lib/ai/prompt-engine.ts → renderPrompt', group: 'engine' },
+  { key: 'engine.continueTail',     label: '续写时取已有正文末尾', unit: 'chars', value: 3000,
+    note: 'chapter.continue 模板里 existingContent.slice(-3000)。', targetCode: 'src/lib/ai/adapters/chapter-adapter.ts → buildContinuePrompt', group: 'engine' },
+  { key: 'engine.previousEnding',   label: '正文写作 · 前一章结尾', unit: 'chars', value: 500,
+    note: 'ChapterEditor 取前一章 plainText 末尾的字符数。', targetCode: 'src/components/editor/ChapterEditor.tsx', group: 'engine' },
+]
+
+/** 全部预算分组（高级设置面板按这个顺序展示） */
+export const BUDGET_GROUPS: { id: BudgetEntry['group']; label: string; entries: BudgetEntry[]; description: string }[] = [
+  { id: 'assemble',       label: '装配总闸',     entries: ASSEMBLE_BUDGETS,        description: 'assembleContext 装配完所有 source 后再施加的全局 token 总闸。超出会按层级裁剪。' },
+  { id: 'context-source', label: '上下文源预算', entries: CONTEXT_SOURCE_BUDGETS,  description: '每个 context source 自己的 token 硬上限，先于装配总闸生效。' },
+  { id: 'reader',         label: 'Reader 截断',  entries: READER_BUDGETS,          description: '各 source 的 reader 函数内部写死的"条数 / 单条字符"上限。' },
+  { id: 'formatter',      label: '字段格式化截断', entries: FORMATTER_BUDGETS,    description: 'context-builder 里把单条记录序列化为文本时，对每个字段做的 slice。' },
+  { id: 'engine',         label: 'Prompt 引擎截断', entries: ENGINE_BUDGETS,      description: '提示词引擎 / 适配器层的尾部裁剪，例如 few-shot 数量、续写取尾长度。' },
+]
+
+/** Leaf entry：把对象型 entry 拆成单值（key + 子字段名）。供高级设置面板和 effective-limits 使用。 */
+export interface BudgetLeaf {
+  /** flat key，例如 'reader.foreshadows.最多条数' / 'src.contextMemo' */
+  flatKey: string
+  /** 顶层 entry */
+  parent: BudgetEntry
+  /** 对象型 entry 的子字段名；单值时为 null */
+  subKey: string | null
+  /** 该 leaf 的默认值（运行时硬编码值） */
+  defaultValue: number
+  /** 面板展示的标签 */
+  label: string
+}
+
+/** 把一个 BudgetEntry 拆成 1+ 个 leaf。 */
+export function flattenBudgetEntry(entry: BudgetEntry): BudgetLeaf[] {
+  if (typeof entry.value === 'number') {
+    return [{ flatKey: entry.key, parent: entry, subKey: null, defaultValue: entry.value, label: entry.label }]
+  }
+  return Object.entries(entry.value).map(([sub, num]) => ({
+    flatKey: `${entry.key}.${sub}`,
+    parent: entry,
+    subKey: sub,
+    defaultValue: num,
+    label: `${entry.label} · ${sub}`,
+  }))
+}

--- a/src/lib/registry/context-sources.ts
+++ b/src/lib/registry/context-sources.ts
@@ -20,6 +20,7 @@ import { buildWorldRulesContext } from '../ai/world-rules-manifest'
 import { parseStages } from '../types/story-arc'
 import { parseFields } from '../types/state-card'
 import { parseBeats } from '../types/emotion-beat'
+import { getEffectiveLimit } from './effective-limits'
 import type { Character, Foreshadow, PowerSystem, Worldview } from '../types'
 import type { ContextSource } from './types'
 
@@ -54,8 +55,11 @@ async function readForeshadows(projectId: number, chapterId?: number | null): Pr
   const rows = await db.foreshadows.where('projectId').equals(projectId).toArray()
   const open = rows.filter(f => f.status !== 'resolved')
   if (!open.length) return ''
+  // H5 — 可调阈值
+  const maxItems = getEffectiveLimit('reader.foreshadows.最多条数', 25)
+  const perItemChars = getEffectiveLimit('reader.foreshadows.单条字符', 120)
   const selected = chapterId == null
-    ? open.slice(0, 25)
+    ? open.slice(0, maxItems)
     : open.filter(f => {
       if (f.plantChapterId === chapterId || f.resolveChapterId === chapterId || f.expectedResolveChapterId === chapterId) return true
       try {
@@ -66,7 +70,7 @@ async function readForeshadows(projectId: number, chapterId?: number | null): Pr
       }
     })
   if (!selected.length) return ''
-  const lines = selected.map((f: Foreshadow) => `- ${f.name}(${f.status}/${f.type}): ${f.description?.slice(0, 120) || ''}`)
+  const lines = selected.map((f: Foreshadow) => `- ${f.name}(${f.status}/${f.type}): ${f.description?.slice(0, perItemChars) || ''}`)
   return `【伏笔状态】\n${lines.join('\n')}`
 }
 
@@ -80,12 +84,17 @@ async function readUserStyleProfile(projectId: number): Promise<string> {
 async function readStoryArcs(projectId: number): Promise<string> {
   const arcs = await db.storyArcs.where('projectId').equals(projectId).toArray()
   if (!arcs.length) return ''
+  // H5 — 可调阈值
+  const maxArcs = getEffectiveLimit('reader.storyArcs.最多故事线', 8)
+  const maxStages = getEffectiveLimit('reader.storyArcs.每条阶段数', 6)
+  const descChars = getEffectiveLimit('reader.storyArcs.描述字符', 120)
+  const stageChars = getEffectiveLimit('reader.storyArcs.阶段字符', 120)
   const parts = ['【全局故事线】']
-  for (const arc of arcs.slice(0, 8)) {
+  for (const arc of arcs.slice(0, maxArcs)) {
     const stages = parseStages(arc.stages)
-    parts.push(`[${arc.type}] ${arc.name}${arc.description ? `:${arc.description.slice(0, 120)}` : ''}`)
-    for (const stage of stages.slice(0, 6)) {
-      parts.push(`- ${stage.title}: ${stage.description.slice(0, 120)}`)
+    parts.push(`[${arc.type}] ${arc.name}${arc.description ? `:${arc.description.slice(0, descChars)}` : ''}`)
+    for (const stage of stages.slice(0, maxStages)) {
+      parts.push(`- ${stage.title}: ${stage.description.slice(0, stageChars)}`)
     }
   }
   return parts.join('\n')
@@ -110,12 +119,15 @@ async function readStateCards(projectId: number, referenceText?: string, extraId
   if (!rows.length) return ''
   const extra = new Set(extraIds ?? [])
   const text = referenceText || ''
+  // H5 — 可调阈值
+  const maxNoRef = getEffectiveLimit('reader.stateCards.无引用文本时', 40)
+  const maxFields = getEffectiveLimit('reader.stateCards.每卡字段数', 8)
   const selected = text
     ? rows.filter(c => extra.has(c.id!) || text.includes(c.entityName))
-    : rows.slice(0, 40)
+    : rows.slice(0, maxNoRef)
   if (!selected.length) return ''
   const lines = selected.map(c => {
-    const fields = parseFields(c.fields).slice(0, 8).map(f => `${f.key}:${f.value}`).join(' | ')
+    const fields = parseFields(c.fields).slice(0, maxFields).map(f => `${f.key}:${f.value}`).join(' | ')
     return `- ${c.category}/${c.entityName}: ${fields}`
   })
   return `【当前状态表】\n${lines.join('\n')}`

--- a/src/lib/registry/effective-limits.ts
+++ b/src/lib/registry/effective-limits.ts
@@ -1,0 +1,110 @@
+/**
+ * Effective limits（H5 — budget / 截断阈值的可调整层）
+ *
+ * 思路：
+ *   - 所有硬截断仍然写在原 reader / formatter / context-source 里作为 **默认值**。
+ *   - 这里只提供 `getEffectiveLimit(key, defaultValue)`：若用户在「高级设置」改过该 key
+ *     则返回用户值，否则返回默认值。
+ *   - 用户值持久化在 localStorage；改完立即广播 CustomEvent，业务侧拉取一次新值即可。
+ *
+ * key 命名规则与 budget-config.ts 中的 leaf 路径一致：
+ *   - 单值 entry：直接用 `key`，例如 'src.contextMemo' / 'assemble.defaultInputBudget'
+ *   - 对象型 entry：用 `parentKey.subFieldName`，例如 'reader.foreshadows.最多条数'
+ *     这样 budget-config 里的对象型 entry（如 reader.storyArcs 含 4 个子字段）
+ *     可以分别被独立调整。
+ *
+ * 该文件本身保持纯同步访问，避免在热路径上引入异步代价。
+ */
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'storyforge.effectiveLimits.v1'
+const EVENT_NAME = 'storyforge:effective-limits-change'
+
+type Snapshot = Record<string, number>
+
+let _cache: Snapshot | null = null
+
+function load(): Snapshot {
+  if (_cache) return _cache
+  if (typeof window === 'undefined') return (_cache = {})
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return (_cache = {})
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      const cleaned: Snapshot = {}
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v === 'number' && Number.isFinite(v) && v > 0) cleaned[k] = v
+      }
+      return (_cache = cleaned)
+    }
+    return (_cache = {})
+  } catch {
+    return (_cache = {})
+  }
+}
+
+function persist(snapshot: Snapshot): void {
+  _cache = snapshot
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
+  } catch {
+    /* 满 / 隐私模式 → 静默失败，本会话仍可读 _cache */
+  }
+  window.dispatchEvent(new CustomEvent(EVENT_NAME))
+}
+
+/** 同步获取生效值；若未被覆盖则返回 fallback。 */
+export function getEffectiveLimit(key: string, fallback: number): number {
+  const snap = load()
+  const v = snap[key]
+  return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : fallback
+}
+
+/** 写入一个覆盖；传 undefined / null / NaN 则视为"恢复默认"。 */
+export function setEffectiveLimit(key: string, value: number | null | undefined): void {
+  const snap = { ...load() }
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    delete snap[key]
+  } else {
+    snap[key] = Math.round(value)
+  }
+  persist(snap)
+}
+
+/** 一次性恢复所有默认值。 */
+export function resetAllEffectiveLimits(): void {
+  persist({})
+}
+
+/** 获取当前完整快照（高级设置面板用以渲染输入框）。 */
+export function getEffectiveLimitsSnapshot(): Snapshot {
+  return { ...load() }
+}
+
+/** 订阅入口（高级设置面板自身需要重渲染） */
+export function onEffectiveLimitsChange(listener: () => void): () => void {
+  if (typeof window === 'undefined') return () => {}
+  const handler = () => listener()
+  window.addEventListener(EVENT_NAME, handler)
+  // 跨标签页
+  const onStorage = (e: StorageEvent) => { if (e.key === STORAGE_KEY) { _cache = null; listener() } }
+  window.addEventListener('storage', onStorage)
+  return () => {
+    window.removeEventListener(EVENT_NAME, handler)
+    window.removeEventListener('storage', onStorage)
+  }
+}
+
+/**
+ * React hook —— 在组件里读 effective limit，自动订阅变化并触发重渲染。
+ * 用于业务面板的字段提示 / 超限警告，使「高级设置」改完之后立即对齐。
+ */
+export function useEffectiveLimit(key: string, fallback: number): number {
+  const [value, setValue] = useState<number>(() => getEffectiveLimit(key, fallback))
+  useEffect(() => {
+    return onEffectiveLimitsChange(() => setValue(getEffectiveLimit(key, fallback)))
+  }, [key, fallback])
+  return value
+}


### PR DESCRIPTION
## 改动说明 / What & Why

解决了上一个PR说到的第六点：
“ 自定义指令注入未解决 ：用户反馈的"自定义指令没进提示词"本 PR 未处理（ ChapterEditor 仍未把 customInstruction 接入正文/续写/扩写构造链路）。若想一并解决请明确实现；否则不要在描述里声称已覆盖。”

修复了世界观模块拼接prompt时的错误重复