### PR TITLE
Opencode provider

### DIFF
--- a/docs/AI-FUNCTIONS-MANUAL.generated.md
+++ b/docs/AI-FUNCTIONS-MANUAL.generated.md
@@ -173,4 +173,4 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 
 ---
 
-生成时间基准:commit `f235652`
+生成时间基准:commit `dd338eb`

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -23,6 +23,7 @@ const PROVIDER_OPTIONS: { value: AIProvider; label: string; cors: boolean; hint:
   { value: 'nvidia', label: 'NVIDIA NIM', cors: false, hint: '获取 Key: build.nvidia.com → 登录后获取 API Key（需点击下方「切换到本地代理」）' },
   { value: 'modelscope', label: '魔搭社区', cors: true, hint: '获取 Key: modelscope.cn → 我的 → Access Token' },
   { value: 'agnes', label: 'Agnes AI（免费）', cors: true, hint: '清华系免费全模态 · 获取 Key: platform.agnes-ai.com（若连不上可点下方「切换到本地代理」）' },
+  { value: 'opencode', label: 'OpenCode Go（月付）', cors: false, hint: '获取 Key: opencode.ai → Settings → API Key · $10/月订阅（需点击下方「切换到本地代理」）' },
   { value: 'ollama', label: 'Ollama (本地)', cors: true, hint: '本地运行 Ollama，无需 API Key' },
   { value: 'custom', label: '自定义', cors: true, hint: '填写任何兼容 OpenAI 格式的 API' },
 ]
@@ -239,6 +240,7 @@ export default function AIConfigPanel() {
                   nvidia:   { proxy: '/nvidia-proxy/v1',   direct: 'https://integrate.api.nvidia.com/v1' },
                   doubao:   { proxy: '/doubao-proxy/api/v3', direct: 'https://ark.cn-beijing.volces.com/api/v3' },
                   agnes:    { proxy: '/agnes-proxy/v1',    direct: 'https://apihub.agnes-ai.com/v1' },
+                  opencode: { proxy: '/opencode-proxy/v1',  direct: 'https://opencode.ai/zen/go/v1' },
                 }
                 const pm = PROXY_MAP[config.provider]
                 if (!pm) return null

--- a/src/lib/ai/context-budget.ts
+++ b/src/lib/ai/context-budget.ts
@@ -85,6 +85,24 @@ export const MODEL_CONTEXT_PRESETS: Record<string, ModelContextPreset> = {
   // ModelScope
   'modelscope': { label: 'ModelScope 默认', maxContext: 32_000, maxOutput: 8_192 },
 
+  // OpenCode Go（月模型订阅服务 · 2026-06）
+  'opencode': { label: 'OpenCode Go 默认', maxContext: 128_000, maxOutput: 16_384 },
+  'opencode:kimi-k2.5': { label: 'Kimi K2.5', maxContext: 256_000, maxOutput: 16_384 },
+  'opencode:kimi-k2.6': { label: 'Kimi K2.6', maxContext: 256_000, maxOutput: 16_384 },
+  'opencode:glm-5.1': { label: 'GLM-5.1', maxContext: 128_000, maxOutput: 16_384 },
+  'opencode:glm-5': { label: 'GLM-5', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:minimax-m2.5': { label: 'MiniMax M2.5', maxContext: 245_000, maxOutput: 16_384 },
+  'opencode:minimax-m2.7': { label: 'MiniMax M2.7', maxContext: 245_000, maxOutput: 16_384 },
+  'opencode:minimax-m3': { label: 'MiniMax M3', maxContext: 245_000, maxOutput: 16_384 },
+  'opencode:mimo-v2.5-pro': { label: 'MiMo-V2.5-Pro', maxContext: 128_000, maxOutput: 16_384 },
+  'opencode:mimo-v2.5': { label: 'MiMo-V2.5', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:qwen3.7-max': { label: 'Qwen3.7 Max', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:qwen3.7-plus': { label: 'Qwen3.7 Plus', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:qwen3.6-plus': { label: 'Qwen3.6 Plus', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:qwen3.5-plus': { label: 'Qwen3.5 Plus', maxContext: 32_000, maxOutput: 8_192 },
+  'opencode:deepseek-v4-flash': { label: 'DeepSeek V4 Flash', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:deepseek-v4-pro': { label: 'DeepSeek V4 Pro', maxContext: 128_000, maxOutput: 16_384 },
+
   // Ollama (本地部署，窗口大小取决于模型)
   'ollama': { label: 'Ollama 默认', maxContext: 8_000, maxOutput: 4_096 },
 

--- a/src/lib/types/ai.ts
+++ b/src/lib/types/ai.ts
@@ -14,6 +14,7 @@ export type AIProvider =
   | 'modelscope'
   | 'nvidia'
   | 'agnes'
+  | 'opencode'
   | 'ollama'
   | 'custom'
 
@@ -117,6 +118,23 @@ export const PROVIDER_MODELS: Record<string, { value: string; label: string; des
     { value: 'agnes-1.5-flash', label: 'Agnes 1.5 Flash', desc: '清华系免费·稳定可用·推荐' },
     { value: 'Agnes-2.0-Flash', label: 'Agnes 2.0 Flash', desc: '1M 上下文·部分时段维护中' },
   ],
+  opencode: [
+    { value: 'kimi-k2.5', label: 'Kimi K2.5 ⭐', desc: '推荐，256K 上下文，复杂编码' },
+    { value: 'kimi-k2.6', label: 'Kimi K2.6', desc: '最新 Kimi，代码质量最高' },
+    { value: 'glm-5.1', label: 'GLM-5.1', desc: '旗舰推理/编码，★★★★★' },
+    { value: 'glm-5', label: 'GLM-5', desc: '中文推理/数学' },
+    { value: 'minimax-m2.5', label: 'MiniMax M2.5', desc: '性价比最高，SWE-Bench 80.2%' },
+    { value: 'minimax-m2.7', label: 'MiniMax M2.7', desc: 'MiniMax 改进版' },
+    { value: 'minimax-m3', label: 'MiniMax M3', desc: '最新 MiniMax' },
+    { value: 'mimo-v2.5-pro', label: 'MiMo-V2.5-Pro', desc: '高质量编码' },
+    { value: 'mimo-v2.5', label: 'MiMo-V2.5', desc: '超值版' },
+    { value: 'qwen3.7-max', label: 'Qwen3.7 Max', desc: 'Qwen 最高质量' },
+    { value: 'qwen3.7-plus', label: 'Qwen3.7 Plus', desc: '均衡 Qwen' },
+    { value: 'qwen3.6-plus', label: 'Qwen3.6 Plus', desc: '高性价比' },
+    { value: 'qwen3.5-plus', label: 'Qwen3.5 Plus', desc: '最大请求量' },
+    { value: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash', desc: '极致性价比' },
+    { value: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro', desc: 'DS 最强' },
+  ],
 }
 
 /** 提供商预设 */
@@ -176,6 +194,10 @@ export const PROVIDER_PRESETS: Record<string, Partial<AIConfig>> = {
   agnes: {
     baseUrl: 'https://apihub.agnes-ai.com/v1',
     model: 'agnes-1.5-flash',
+  },
+  opencode: {
+    baseUrl: 'https://opencode.ai/zen/go/v1',
+    model: 'kimi-k2.5',
   },
   ollama: {
     baseUrl: 'http://localhost:11434/v1',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -106,6 +106,12 @@ export default defineConfig({
         rewrite: (path: string) => path.replace(/^\/agnes-proxy/, ''),
         secure: true,
       },
+      '/opencode-proxy': {
+        target: 'https://opencode.ai',
+        changeOrigin: true,
+        rewrite: (path: string) => path.replace(/^\/opencode-proxy/, '/zen/go'),
+        secure: true,
+      },
       // NS-5 embedding：国内嵌入服务本地代理（绕浏览器 CORS）
       '/siliconflow-proxy': {
         target: 'https://api.siliconflow.cn',


### PR DESCRIPTION
## 改动说明 / What & Why

为 StoryForge 添加 **OpenCode Go** 作为新的 AI 供应商。

OpenCode Go 是一个 **$10/月模型订阅服务**（参见 [opencode.ai/docs/zh-cn/go](https://opencode.ai/docs/zh-cn/go)），提供 OpenAI 兼容 API，涵盖 Kimi K2.5/K2.6、GLM-5/5.1、MiniMax M2.5/M2.7/M3、MiMo-V2.5/V2.5-Pro、Qwen3.5/3.6/3.7、DeepSeek V4 Flash/Pro 共 15 款模型。

将该供应商排在 **Ollama 上一行**（Agnes 之后），标记 `cors: false`（需本地代理绕过 CORS）。

## 关联 Issue / Related issue

<!-- 无关联 Issue -->

## 自检清单 / Checklist

- [x] 已读 `CLAUDE.md`,改动遵循三注册表铁律(未直接调 db / 未手挑上下文 / 未手写表清单)
  - 改动纯属在现有枚举/预设/模型列表/UI 选项中追加一个枚举值，无需新增表/字段/AI 动作/上下文源
- [x] `npm run ci` 本地全绿(check:required-tables / check:ai-manual / check:architecture / tsc / test / build)
  - `check:required-tables` ✅ 42 tables match
  - `check:ai-manual` ✅ generated manual matches code
  - `check:architecture` ✅ 无反模式违规
  - `tsc --noEmit` ✅ 零错误
  - `test:coverage` ✅ 78 files / 300 tests / 0 failures
  - `build` ✅ built in 41.78s
- [x] 若改了 DB schema:已写迁移测试 + 真实数据实测
  - **不适用**：未改动 DB schema
- [x] 若加了表/字段/上下文源/AI 动作:已同步对应注册表
  - **不适用**：未新增表/字段/上下文源/AI 动作
- [x] 若改了 AI 行为:已跑 `npm run gen:ai-manual` 重新生成说明书
  - **不适用**：未改动 AI prompt 或行为逻辑
- [x] 修 bug 的:已有一条会失败→变绿的反例测试
  - **不适用**：新功能而非 bug 修复
