### PR TITLE
feat(ai): add OpenCode Go provider

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -211,6 +211,16 @@
 
 ---
 
+## 🟡 PR-20260702-20 — OpenCode Go AI provider 接入
+
+- **来源**：外部贡献者 PR [#20 Opencode provider](https://github.com/yuanbw2025/storyforge/pull/20)。
+- **状态**：PR 当前与 `main` 冲突且无 checks；不直接合并，改由 Codex 在 `codex/opencode-provider` 分支参考实现，并在关闭 PR 时向贡献者致谢说明。
+- **改动范围**：仅新增 AI provider 枚举 / 模型列表 / 默认 Base URL / 设置页选项 / Vite 本地代理 / 上下文窗口预设；不改 DB schema，不新增 AI 动作，不涉及三注册表数据读写。
+- **实现注意**：StoryForge 当前 AI client 只调用 OpenAI-compatible `/chat/completions`；OpenCode Go 官方文档中 MiniMax/Qwen 等模型走 `/messages`，本轮先只暴露明确支持 `/chat/completions` 的模型，后续若支持 Anthropic messages 端点再扩。
+- **验证**：`check:required-tables` / `check:architecture` / `check:ai-manual` / `tsc` / targeted tests / build。
+
+---
+
 # ═══ 社区反馈批次（2026-07-02 · 角色弧光 / 生成一致性 / 本地模型 / 输入法 / 流派约束）═══
 
 > **来源**：2026-07-02 群内用户截图 + 录屏，附件包括 `QQ20260702-100105.mp4` 与 7 张截图。

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -24,6 +24,7 @@ const PROVIDER_OPTIONS: { value: AIProvider; label: string; cors: boolean; hint:
   { value: 'modelscope', label: '魔搭社区', cors: true, hint: '获取 Key: modelscope.cn → 我的 → Access Token' },
   { value: 'agnes', label: 'Agnes AI（免费）', cors: true, hint: '清华系免费全模态 · 获取 Key: platform.agnes-ai.com（若连不上可点下方「切换到本地代理」）' },
   { value: 'longcat', label: 'LongCat（美团）', cors: false, hint: '获取 Key: longcat.chat 平台控制台；OpenAI 兼容接口（若浏览器直连 CORS 失败可切换本地代理）' },
+  { value: 'opencode', label: 'OpenCode Go（月付）', cors: false, hint: '获取 Key: opencode.ai → Zen → Go API Key（需点击下方「切换到本地代理」）' },
   { value: 'ollama', label: 'Ollama (本地)', cors: true, hint: '本地运行 Ollama，无需 API Key' },
   { value: 'custom', label: '自定义', cors: true, hint: '填写任何兼容 OpenAI 格式的 API' },
 ]
@@ -265,6 +266,7 @@ export default function AIConfigPanel() {
                   doubao:   { proxy: '/doubao-proxy/api/v3', direct: 'https://ark.cn-beijing.volces.com/api/v3' },
                   agnes:    { proxy: '/agnes-proxy/v1',    direct: 'https://apihub.agnes-ai.com/v1' },
                   longcat:  { proxy: '/longcat-proxy/openai/v1', direct: 'https://api.longcat.chat/openai/v1' },
+                  opencode: { proxy: '/opencode-proxy/v1',  direct: 'https://opencode.ai/zen/go/v1' },
                 }
                 const pm = PROXY_MAP[config.provider]
                 if (!pm) return null

--- a/src/lib/ai/context-budget.ts
+++ b/src/lib/ai/context-budget.ts
@@ -86,6 +86,17 @@ export const MODEL_CONTEXT_PRESETS: Record<string, ModelContextPreset> = {
   'longcat': { label: 'LongCat 默认', maxContext: 1_000_000, maxOutput: 128_000 },
   'longcat:LongCat-2.0': { label: 'LongCat 2.0', maxContext: 1_000_000, maxOutput: 128_000 },
 
+  // OpenCode Go(chat/completions 兼容模型)
+  'opencode': { label: 'OpenCode Go 默认', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:kimi-k2.7-code': { label: 'Kimi K2.7 Code', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:kimi-k2.6': { label: 'Kimi K2.6', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:glm-5.2': { label: 'GLM-5.2', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:glm-5.1': { label: 'GLM-5.1', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:deepseek-v4-pro': { label: 'DeepSeek V4 Pro', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:deepseek-v4-flash': { label: 'DeepSeek V4 Flash', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:mimo-v2.5-pro': { label: 'MiMo-V2.5-Pro', maxContext: 128_000, maxOutput: 8_192 },
+  'opencode:mimo-v2.5': { label: 'MiMo-V2.5', maxContext: 128_000, maxOutput: 8_192 },
+
   // ModelScope
   'modelscope': { label: 'ModelScope 默认', maxContext: 32_000, maxOutput: 8_192 },
 

--- a/src/lib/types/ai.ts
+++ b/src/lib/types/ai.ts
@@ -15,6 +15,7 @@ export type AIProvider =
   | 'nvidia'
   | 'agnes'
   | 'longcat'
+  | 'opencode'
   | 'ollama'
   | 'custom'
 
@@ -121,6 +122,16 @@ export const PROVIDER_MODELS: Record<string, { value: string; label: string; des
   longcat: [
     { value: 'LongCat-2.0', label: 'LongCat 2.0', desc: '美团 LongCat · OpenAI 兼容 · 1M 上下文' },
   ],
+  opencode: [
+    { value: 'kimi-k2.7-code', label: 'Kimi K2.7 Code', desc: 'OpenCode Go · chat/completions' },
+    { value: 'kimi-k2.6', label: 'Kimi K2.6', desc: 'OpenCode Go · chat/completions' },
+    { value: 'glm-5.2', label: 'GLM-5.2', desc: 'OpenCode Go · chat/completions' },
+    { value: 'glm-5.1', label: 'GLM-5.1', desc: 'OpenCode Go · chat/completions' },
+    { value: 'deepseek-v4-pro', label: 'DeepSeek V4 Pro', desc: 'OpenCode Go · chat/completions' },
+    { value: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash', desc: 'OpenCode Go · chat/completions' },
+    { value: 'mimo-v2.5-pro', label: 'MiMo-V2.5-Pro', desc: 'OpenCode Go · chat/completions' },
+    { value: 'mimo-v2.5', label: 'MiMo-V2.5', desc: 'OpenCode Go · chat/completions' },
+  ],
 }
 
 /** 提供商预设 */
@@ -184,6 +195,10 @@ export const PROVIDER_PRESETS: Record<string, Partial<AIConfig>> = {
   longcat: {
     baseUrl: 'https://api.longcat.chat/openai/v1',
     model: 'LongCat-2.0',
+  },
+  opencode: {
+    baseUrl: 'https://opencode.ai/zen/go/v1',
+    model: 'kimi-k2.7-code',
   },
   ollama: {
     baseUrl: 'http://localhost:11434/v1',

--- a/tests/regression/R-opencode-provider.test.ts
+++ b/tests/regression/R-opencode-provider.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { PROVIDER_MODELS, PROVIDER_PRESETS, type AIProvider } from '../../src/lib/types/ai'
+import { getModelPreset } from '../../src/lib/ai/context-budget'
+
+describe('R-OPENCODE · OpenCode Go provider', () => {
+  it('provider preset points to the OpenCode Go OpenAI-compatible base URL', () => {
+    const preset = PROVIDER_PRESETS.opencode
+    expect(preset.baseUrl).toBe('https://opencode.ai/zen/go/v1')
+    expect(preset.model).toBe('kimi-k2.7-code')
+  })
+
+  it('model list only exposes chat/completions-compatible models for the current client', () => {
+    const models = PROVIDER_MODELS.opencode?.map(item => item.value)
+    expect(models).toContain('kimi-k2.7-code')
+    expect(models).toContain('deepseek-v4-pro')
+    expect(models).not.toContain('qwen3.7-max')
+    expect(models).not.toContain('minimax-m3')
+  })
+
+  it('context budget has a provider fallback and exact model preset', () => {
+    const fallback = getModelPreset('opencode' as AIProvider, 'unknown-model')
+    const exact = getModelPreset('opencode' as AIProvider, 'kimi-k2.7-code')
+    expect(fallback.maxContext).toBe(128_000)
+    expect(exact.label).toBe('Kimi K2.7 Code')
+    expect(exact.maxContext).toBe(128_000)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -116,6 +116,12 @@ export default defineConfig({
         rewrite: (path: string) => path.replace(/^\/longcat-proxy/, ''),
         secure: true,
       },
+      '/opencode-proxy': {
+        target: 'https://opencode.ai',
+        changeOrigin: true,
+        rewrite: (path: string) => path.replace(/^\/opencode-proxy/, '/zen/go'),
+        secure: true,
+      },
       // NS-5 embedding：国内嵌入服务本地代理（绕浏览器 CORS）
       '/siliconflow-proxy': {
         target: 'https://api.siliconflow.cn',


### PR DESCRIPTION
## What\n\nAdds OpenCode Go as an AI provider without merging external PR #20 directly. The implementation references and credits #20, but rebases the change onto current main and keeps the model list limited to OpenAI-compatible `/chat/completions` models supported by StoryForge's current AI client.\n\n## Changes\n\n- Add `opencode` to AI provider types, presets, and model list\n- Add OpenCode Go option and local proxy switch in AI settings\n- Add OpenCode context-window presets\n- Add Vite dev proxy for `/opencode-proxy`\n- Record PR #20 handling in ROADMAP\n- Add regression coverage for provider preset/model/budget wiring\n\n## Verification\n\nLocal branch verification before remote-main advanced:\n- `npm run check:required-tables`\n- `npm run check:architecture`\n- `npm run check:ai-manual`\n- `npx tsc --noEmit`\n- `npx vitest run tests/regression/R-opencode-provider.test.ts`\n- `npm test`\n- `npm run build`\n\nAfter remote main advanced to `42d985a`, the patch was checked cleanly against the new main before creating this branch via GitHub API. CI should now validate the branch on the current base.\n\n## Notes\n\nCloses/handles external contribution #20 separately; after this lands, we can close #20 with thanks and explain that the functionality was reimplemented on a fresh Codex branch because the original PR was conflicting and had no checks.