### PR TITLE
修复细纲生成和上一章尾注入错误

### DIFF
--- a/docs/AI-FUNCTIONS-MANUAL.generated.md
+++ b/docs/AI-FUNCTIONS-MANUAL.generated.md
@@ -124,19 +124,19 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 | category | 触发文件 |
 |---|---|
 | `ai.restructure` | `src/lib/ai/restructure.ts:52` |
-| `chapter.content` | `src/components/editor/ChapterEditor.tsx:425` |
+| `chapter.content` | `src/components/editor/ChapterEditor.tsx:426` |
 | `chapter.content.batch` | `src/lib/ai/batch-detail-runner.ts:256` |
-| `chapter.continue` | `src/components/editor/ChapterEditor.tsx:443` |
-| `chapter.deai` | `src/components/editor/ChapterEditor.tsx:480` |
-| `chapter.expand` | `src/components/editor/ChapterEditor.tsx:460` |
-| `chapter.memory` | `src/components/editor/ChapterEditor.tsx:258` |
-| `chapter.polish` | `src/components/editor/ChapterEditor.tsx:452` |
+| `chapter.continue` | `src/components/editor/ChapterEditor.tsx:444` |
+| `chapter.deai` | `src/components/editor/ChapterEditor.tsx:481` |
+| `chapter.expand` | `src/components/editor/ChapterEditor.tsx:461` |
+| `chapter.memory` | `src/components/editor/ChapterEditor.tsx:259` |
+| `chapter.polish` | `src/components/editor/ChapterEditor.tsx:453` |
 | `chapter.toolbar` | `src/components/editor/FloatingToolbar.tsx:105` |
 | `character.generate` | `src/components/character/CharacterPanel.tsx:163` |
 | `character.structure` | `src/lib/ai/parse-character-output.ts:80` |
 | `character.supplement` | `src/components/character/CharacterSupplementAction.tsx:80` |
 | `codex.extract` | `src/components/codex/CodexPanel.tsx:204` |
-| `detail.scene` | `src/components/outline/DetailedOutlinePanel.tsx:163`<br/>`src/components/outline/ScenePanel.tsx:111`<br/>`src/lib/ai/batch-detail-runner.ts:109` |
+| `detail.scene` | `src/components/outline/DetailedOutlinePanel.tsx:163`<br/>`src/components/outline/ScenePanel.tsx:115`<br/>`src/lib/ai/batch-detail-runner.ts:109` |
 | `emotion.beat` | `src/components/editor/EmotionBeatCard.tsx:66` |
 | `foreshadow.structure` | `src/components/foreshadow/ForeshadowPanel.tsx:66` |
 | `foreshadow.suggest` | `src/components/foreshadow/ForeshadowPanel.tsx:215` |
@@ -155,7 +155,7 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 | `review.anti-ai` | `src/components/editor/ReviewPanel.tsx:86` |
 | `review.quality` | `src/components/editor/ReviewPanel.tsx:78` |
 | `review.readability` | `src/components/editor/ReviewPanel.tsx:95` |
-| `review.revise` | `src/components/editor/ChapterEditor.tsx:495` |
+| `review.revise` | `src/components/editor/ChapterEditor.tsx:496` |
 | `rules.generate` | `src/components/rules/CreativeRulesPanel.tsx:80` |
 | `scene.verify` | `src/components/scene/SceneVerifyPanel.tsx:81` |
 | `story-arc.generate` | `src/components/outline/StoryArcPanel.tsx:84` |
@@ -176,4 +176,4 @@ AI 输出经 `adopt({ target, data })` 写回,只有这里登记的字段可写(
 
 ---
 
-生成时间基准:commit `69c1fb2`
+生成时间基准:commit `dbb3760`

--- a/src/components/editor/ChapterEditor.tsx
+++ b/src/components/editor/ChapterEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { Save, FileText, Eye, ClipboardList, CheckSquare, Square, BookOpenCheck, ShieldCheck, StickyNote } from 'lucide-react'
 import { useChapterStore } from '../../stores/chapter'
 import { useOutlineStore } from '../../stores/outline'
+import { findPrevChapter, findNextChapter } from '../../lib/outline/selectors'
 import { useStateCardStore } from '../../stores/state-card'
 import { useCharacterStore } from '../../stores/character'
 import { useAIStream } from '../../hooks/useAIStream'
@@ -1024,11 +1025,11 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
             worldContext={worldCtx}
             characterContext={charCtx}
             prevChapterSummary={(() => {
-              const prev = chapters.filter(c => c.order < (currentChapter?.order || 0)).pop()
+              const prev = findPrevChapter(nodes, chapters, currentChapter)
               return prev?.summary || ''
             })()}
             nextChapterSummary={(() => {
-              const next = chapters.filter(c => c.order > (currentChapter?.order || 0)).shift()
+              const next = findNextChapter(nodes, chapters, currentChapter)
               return next?.summary || ''
             })()}
             foreshadowContext={currentChapter?.id ? buildForeshadowContext(currentChapter.id, chapters, nodes) : ''}
@@ -1057,7 +1058,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
           worldContext={worldCtx}
           characterContext={charCtx}
           prevChapterEnding={(() => {
-            const prev = chapters.filter(c => c.order < (currentChapter?.order || 0)).pop()
+            const prev = findPrevChapter(nodes, chapters, currentChapter)
             return htmlToPlainText(prev?.content || '').slice(-500)
           })()}
         />

--- a/src/components/outline/ScenePanel.tsx
+++ b/src/components/outline/ScenePanel.tsx
@@ -8,11 +8,13 @@ import { Plus, Trash2, Sparkles, ChevronDown, ChevronRight } from 'lucide-react'
 import { useDetailedOutlineStore } from '../../stores/detailed-outline'
 import { useAIStream } from '../../hooks/useAIStream'
 import { createAISessionKey } from '../../stores/ai-generation-session'
-import { buildDetailSceneGeneratePrompt } from '../../lib/ai/adapters/detail-scene-adapter'
+import { buildDetailSceneGeneratePrompt, parseEnhancedDetailSmart } from '../../lib/ai/adapters/detail-scene-adapter'
 import AIStreamOutput from '../shared/AIStreamOutput'
 import { nanoid } from '../../lib/utils/id'
 import { adopt } from '../../lib/registry/adopt'
 import { assembleContext } from '../../lib/registry/assemble-context'
+import { useAIConfigStore } from '../../stores/ai-config'
+import { useToast } from '../shared/Toast'
 import type { DetailedScene, ScenePace } from '../../lib/types'
 
 const PACE_LABELS: Record<ScenePace, string> = {
@@ -39,6 +41,8 @@ interface Props {
 export default function ScenePanel({ projectId, outlineNodeId, chapterTitle, chapterSummary }: Props) {
   const { detailedOutlines, loadAll, getOrCreate, save } = useDetailedOutlineStore()
   const ai = useAIStream(createAISessionKey(projectId, 'detail.scene', outlineNodeId))
+  const aiConfig = useAIConfigStore(s => s.config)
+  const toast = useToast()
   const [expanded, setExpanded] = useState(false)
 
   useEffect(() => { loadAll(projectId) }, [projectId, loadAll])
@@ -150,21 +154,34 @@ export default function ScenePanel({ projectId, outlineNodeId, chapterTitle, cha
               onStop={ai.stop}
               onAccept={async (text) => {
                 try {
-                  if (!detailed || detailed.scenes.length === 0) {
-                    const newScene: DetailedScene = {
-                      sceneId: nanoid(),
-                      title: '新场景', summary: '',
-                      characterIds: [], location: '', conflict: '',
-                      pace: 'medium', estimatedWords: 0, notes: text,
-                    }
-                    await adoptScenes([newScene])
-                  } else {
-                    await adoptScenes(detailed.scenes.map((s, i) =>
-                      i === 0 ? { ...s, notes: text } : s
-                    ))
+                  // 复用「完善细纲」同款结构化解析器（JSON 优先 → AI 重构兜底，不降级到正则）。
+                  // 修复前：整段 AI 原文被丢进第 0 个场景的 notes，title/summary/conflict 全空，
+                  // 而细纲注入(readDetailedOutline)只读 summary/conflict/location 不读 notes →
+                  // 场景堆一处、手动改不了、注入为空壳。改为解析成结构化 scenes 逐条落表。
+                  const parsed = await parseEnhancedDetailSmart(text, aiConfig)
+                  const parsedScenes = parsed?.scenes
+                  if (!parsedScenes || parsedScenes.length === 0) {
+                    toast.error('未能从 AI 输出解析出场景，请重试')
+                    return
                   }
+                  const VALID_PACE: ScenePace[] = ['slow', 'medium', 'fast', 'climax']
+                  const newScenes: DetailedScene[] = parsedScenes.map(s => ({
+                    sceneId: nanoid(),
+                    title: s.title || '未命名场景',
+                    summary: s.summary || '',
+                    characterIds: Array.isArray(s.characterIds) ? s.characterIds : [],
+                    location: s.location || '',
+                    conflict: s.conflict || '',
+                    pace: (VALID_PACE as string[]).includes(s.pace) ? (s.pace as ScenePace) : 'medium',
+                    estimatedWords: typeof s.estimatedWords === 'number' ? s.estimatedWords : 0,
+                    notes: '',
+                  }))
+                  const existing = detailed?.scenes || []
+                  await adoptScenes([...existing, ...newScenes])
+                  toast.success(`已采纳 ${newScenes.length} 个场景`)
                 } catch (err) {
                   console.error('[ScenePanel] 采纳失败:', err)
+                  toast.error('采纳场景失败，请重试')
                 }
                 ai.reset()
               }}

--- a/src/lib/ai/prompt-seeds.ts
+++ b/src/lib/ai/prompt-seeds.ts
@@ -1134,14 +1134,21 @@ D) 以上的混合
 3. 每个场景必须有明确的"小目标"和"小冲突"
 4. 场景间用悬念或情绪转折衔接
 
-输出格式：使用编号列表，每个场景包含：
-- 场景标题
-- 一句话概要
-- 主要人物
-- 发生地点
-- 核心冲突
-- 节奏标签（慢/中/快/高潮）
-- 估算字数`,
+输出严格 JSON，不要加 markdown 代码块、不要任何解释文字：
+{
+  "scenes": [
+    {
+      "title": "场景标题",
+      "summary": "一句话场景概要",
+      "location": "发生地点",
+      "conflict": "核心冲突",
+      "pace": "slow|medium|fast|climax",
+      "estimatedWords": 2000
+    }
+  ]
+}
+
+pace 只能取 slow / medium / fast / climax 四个值之一；estimatedWords 为整数。`,
     userPromptTemplate: `章节标题：{{chapterTitle}}
 章节大纲：{{chapterSummary}}{{#if worldContext}}
 

--- a/src/lib/outline/selectors.ts
+++ b/src/lib/outline/selectors.ts
@@ -1,4 +1,4 @@
-import type { OutlineNode } from '../types'
+import type { OutlineNode, Chapter } from '../types'
 
 type OutlineLike = Pick<OutlineNode, 'type'> & { parentId?: number | null }
 
@@ -29,4 +29,86 @@ export function estimateChaptersPerVolume(
   const perChapter = wordsPerChapter > 0 ? wordsPerChapter : DEFAULT_WORDS_PER_CHAPTER
   const perVolumeWords = total / vols
   return Math.max(1, Math.round(perVolumeWords / perChapter))
+}
+
+/**
+ * 章节的「叙事位置」索引：outlineNodeId → 大纲树前序 DFS 序（越小越早）。
+ *
+ * 为什么不用 chapter.order：`chapter.order` 是正文记录**入库时的序号**
+ * （建章处写死 `order: chapters.length`），记录的是"第几个被创建"，
+ * 不是章节在故事里的叙事位置。用户若先进第 2 章写作，其正文记录反而先建、
+ * order 更小，导致"取前一章"错乱（第 2 章被判成第一章）。
+ * 章节的真实叙事顺序由大纲树（volume → arc/storyBlock → chapter）的前序 DFS 决定，
+ * 与 ChaptersListPanel 的展示序一致。本函数即该唯一口径。
+ *
+ * 纯函数、可单测、不碰 DB，也不依赖任何专有模块。
+ */
+export function buildChapterNarrativeOrder(nodes: OutlineNode[]): ReadonlyMap<number, number> {
+  const byParent = new Map<number | null, OutlineNode[]>()
+  for (const n of nodes) {
+    const p = n.parentId ?? null
+    const list = byParent.get(p) || []
+    list.push(n)
+    byParent.set(p, list)
+  }
+  for (const list of byParent.values()) list.sort((a, b) => a.order - b.order)
+
+  const index = new Map<number, number>()
+  let pos = 0
+  const visit = (parentId: number | null) => {
+    for (const n of byParent.get(parentId) || []) {
+      if (n.id != null) index.set(n.id, pos++)
+      visit(n.id ?? null)
+    }
+  }
+  visit(null)
+  return index
+}
+
+/**
+ * 按叙事顺序取「前一章」正文记录（叙事序上紧邻当前章、且更早的那一章）。
+ * currentChapter 未定位到大纲序、或它已是第一章时返回 undefined。
+ * 替代旧写法 `chapters.filter(c => c.order < currentChapter.order).pop()`
+ * ——后者既用错了 order 语义、又依赖数组有序（.pop()）。
+ */
+export function findPrevChapter(
+  nodes: OutlineNode[],
+  chapters: Chapter[],
+  currentChapter: Chapter | null | undefined,
+): Chapter | undefined {
+  return adjacentChapter(nodes, chapters, currentChapter, 'prev')
+}
+
+/** 按叙事顺序取「后一章」正文记录。currentChapter 已是最后一章时返回 undefined。 */
+export function findNextChapter(
+  nodes: OutlineNode[],
+  chapters: Chapter[],
+  currentChapter: Chapter | null | undefined,
+): Chapter | undefined {
+  return adjacentChapter(nodes, chapters, currentChapter, 'next')
+}
+
+function adjacentChapter(
+  nodes: OutlineNode[],
+  chapters: Chapter[],
+  currentChapter: Chapter | null | undefined,
+  dir: 'prev' | 'next',
+): Chapter | undefined {
+  if (!currentChapter) return undefined
+  const order = buildChapterNarrativeOrder(nodes)
+  const curPos = order.get(currentChapter.outlineNodeId)
+  if (curPos == null) return undefined
+
+  let best: Chapter | undefined
+  let bestPos = dir === 'prev' ? -Infinity : Infinity
+  for (const ch of chapters) {
+    if (ch.id === currentChapter.id) continue
+    const pos = order.get(ch.outlineNodeId)
+    if (pos == null) continue
+    if (dir === 'prev' ? (pos < curPos && pos > bestPos) : (pos > curPos && pos < bestPos)) {
+      best = ch
+      bestPos = pos
+    }
+  }
+  return best
 }

--- a/tests/regression/R-32-prev-chapter-narrative-order.test.ts
+++ b/tests/regression/R-32-prev-chapter-narrative-order.test.ts
@@ -1,0 +1,88 @@
+/**
+ * R-32 · 「前一章」必须按叙事顺序取，而非 chapter.order（入库序）
+ *
+ * 症状：第 2 章生成正文时，"前一章结尾"注入为空、被 chapter-adapter 判成"（这是第一章）"。
+ *
+ * 根因：`Chapter.order` 是正文记录**入库时的序号**（建章处写死 `order: chapters.length`），
+ *       记录"第几个被创建"，不是章节的叙事位置。用户若先进第 2 章写作，其正文记录先建、
+ *       order=0，`filter(c => c.order < currentChapter.order).pop()` 恒为空 → 判成第一章。
+ *       且 `.pop()` 依赖数组有序，而 addChapter 是无序 append，进一步放大。
+ *
+ * 修复：新增纯函数 findPrevChapter/findNextChapter，按大纲树前序 DFS 序（叙事顺序，
+ *       与 ChaptersListPanel 展示一致）经 chapter.outlineNodeId 定位相邻章，不看 chapter.order。
+ *
+ * 本测试锁定：入库序与叙事序颠倒时仍能取对前/后章；跨中间层嵌套；边界（首章无前、末章无后）。
+ */
+import { describe, it, expect } from 'vitest'
+import type { OutlineNode, Chapter } from '../../src/lib/types'
+import { findPrevChapter, findNextChapter, buildChapterNarrativeOrder } from '../../src/lib/outline/selectors'
+
+function node(id: number, parentId: number | null, type: OutlineNode['type'], order: number): OutlineNode {
+  return { id, projectId: 1, parentId, type, title: `n${id}`, summary: '', order, createdAt: 0, updatedAt: 0 }
+}
+function chapter(id: number, outlineNodeId: number, order: number): Chapter {
+  return { id, projectId: 1, outlineNodeId, title: `ch${id}`, content: '', wordCount: 0, status: 'outline', order, notes: '', createdAt: 0, updatedAt: 0 }
+}
+
+describe('R-32 · findPrevChapter 按叙事序而非入库序', () => {
+  // 大纲：卷(1) → 章节点 10（第1章）、11（第2章），叙事序 10 在 11 前
+  const nodes: OutlineNode[] = [
+    node(1, null, 'volume', 0),
+    node(10, 1, 'chapter', 0),   // 第1章（叙事上更早）
+    node(11, 1, 'chapter', 1),   // 第2章
+  ]
+
+  it('入库序颠倒（先建第2章）时，第2章仍能取到第1章为前一章', () => {
+    // 用户先进第2章写作 → 第2章正文先建 order=0；再建第1章 order=1（入库序与叙事序颠倒）
+    const ch2 = chapter(100, 11, 0)   // 第2章：order=0
+    const ch1 = chapter(101, 10, 1)   // 第1章：order=1
+    const chapters = [ch2, ch1]       // 数组顺序也无序（模拟 append）
+
+    const prev = findPrevChapter(nodes, chapters, ch2)
+    expect(prev?.id).toBe(101)        // 旧写法这里会得 undefined → 判成第一章
+  })
+
+  it('真正的第一章没有前一章', () => {
+    const ch1 = chapter(101, 10, 1)
+    const ch2 = chapter(100, 11, 0)
+    expect(findPrevChapter(nodes, [ch2, ch1], ch1)).toBeUndefined()
+  })
+
+  it('findNextChapter：第1章的后一章是第2章；第2章无后章', () => {
+    const ch1 = chapter(101, 10, 1)
+    const ch2 = chapter(100, 11, 0)
+    const chapters = [ch2, ch1]
+    expect(findNextChapter(nodes, chapters, ch1)?.id).toBe(100)
+    expect(findNextChapter(nodes, chapters, ch2)).toBeUndefined()
+  })
+
+  it('跨中间层嵌套：叙事序取相邻，忽略 order 与数组序', () => {
+    const deep: OutlineNode[] = [
+      node(1, null, 'volume', 0),
+      node(2, 1, 'chapter', 0),        // 叙事序 pos1（卷 pos0）
+      node(3, 1, 'storyBlock', 1),
+      node(4, 3, 'chapter', 0),        // 叙事序 pos3
+      node(5, 3, 'chapter', 1),        // 叙事序 pos4
+    ]
+    const c2 = chapter(200, 2, 5)
+    const c4 = chapter(201, 4, 3)
+    const c5 = chapter(202, 5, 9)
+    const chapters = [c5, c2, c4]
+    // c5 的前一章应是 c4（叙事相邻），而不是 order/数组序意义上的邻居
+    expect(findPrevChapter(deep, chapters, c5)?.id).toBe(201)
+    // c4 的前一章是 c2（跨过 storyBlock 中间层）
+    expect(findPrevChapter(deep, chapters, c4)?.id).toBe(200)
+  })
+
+  it('currentChapter 的节点不在大纲树中（悬空）时返回 undefined', () => {
+    const orphan = chapter(300, 999, 0)
+    expect(findPrevChapter(nodes, [orphan], orphan)).toBeUndefined()
+  })
+
+  it('buildChapterNarrativeOrder：前序 DFS，卷排在其子章之前', () => {
+    const order = buildChapterNarrativeOrder(nodes)
+    expect(order.get(1)).toBe(0)   // 卷
+    expect(order.get(10)).toBe(1)  // 第1章
+    expect(order.get(11)).toBe(2)  // 第2章
+  })
+})


### PR DESCRIPTION
## 概述
修复两个独立缺陷，分两个 commit：

### ① fix(chapter)：前一章按叙事序取而非入库序
**症状**：第 2 章生成正文时"前一章结尾"为空，被判成"（这是第一章）"。

**根因**：`Chapter.order` 是正文记录的**入库序号**（建章处写死 `order: chapters.length`），
不是叙事位置。用户先进第 2 章写作 → 其记录先建 order=0 →
`chapters.filter(c => c.order < currentChapter.order).pop()` 恒为空 → 判成第一章。
`.pop()` 又依赖数组有序，而 `addChapter` 是无序 append，进一步放大。

**改法**：新增自包含纯函数 `findPrevChapter` / `findNextChapter` /
`buildChapterNarrativeOrder`（`src/lib/outline/selectors.ts`），按大纲树前序 DFS 序
经 `outlineNodeId` 定位相邻章，与章节列表展示序一致。ChapterEditor 调用点全替换。

### ② fix(detail)：一键拆场景解析结构化场景
**症状**：AI 一键拆场景把生成的多个场景一股脑堆进第 0 个场景的 notes（手动改不了），
且导致细纲注入为空。

**根因**：`detail.scene` prompt 让 AI 出编号列表，但 `ScenePanel.onAccept` 不解析，
整段原文丢进 notes。而细纲注入 `readDetailedOutline` 只读 summary/conflict/location
不读 notes → 场景堆一处、注入空壳。

**改法**：`detail.scene` prompt 改输出严格 JSON；`onAccept` 复用已有的
`parseEnhancedDetailSmart`（JSON 优先→AI 重构兜底）解析成结构化 `DetailedScene[]`
逐条落表。改 prompt 后重生成了 AI 手册。

## 验证
- 新增反例 `tests/regression/R-32-prev-chapter-narrative-order.test.ts`（6 例：
  入库序颠倒 / 跨中间层嵌套 / 边界 / 悬空节点）。
- `tsc --noEmit` 0 错；全套测试 352/352 全绿。