### PR TITLE
feat(ai): 自定义 OpenAI 网关开发环境本地代理（CORS）

### DIFF
--- a/scripts/vite-custom-proxy-plugin.mjs
+++ b/scripts/vite-custom-proxy-plugin.mjs
@@ -1,0 +1,120 @@
+/**
+ * Vite 开发插件：/custom-proxy/{http|https}/{host}{path}
+ * 动态转发到任意 OpenAI 兼容上游，绕过浏览器 CORS。
+ * 仅 dev server 有效。
+ *
+ * 解析规则与 src/lib/ai/custom-proxy.ts 保持一致（此处内联，避免 .mjs 直接 import .ts）。
+ */
+import http from 'node:http'
+import https from 'node:https'
+
+const CUSTOM_PROXY_PREFIX = '/custom-proxy'
+
+/**
+ * @param {string} requestPath
+ * @returns {{ targetOrigin: string, upstreamPath: string } | null}
+ */
+function parseCustomProxyPath(requestPath) {
+  const raw = (requestPath || '').trim()
+  if (!raw.startsWith(CUSTOM_PROXY_PREFIX)) return null
+
+  const qIndex = raw.indexOf('?')
+  const pathOnly = qIndex >= 0 ? raw.slice(0, qIndex) : raw
+  const query = qIndex >= 0 ? raw.slice(qIndex) : ''
+
+  const rest = pathOnly.slice(CUSTOM_PROXY_PREFIX.length).replace(/^\//, '')
+  const match = rest.match(/^(https?)\/([^/]+)(.*)$/i)
+  if (!match) return null
+
+  const protocol = match[1].toLowerCase()
+  const host = match[2]
+  let upstreamPath = `${match[3] || '/'}${query}`
+  if (!upstreamPath.startsWith('/')) upstreamPath = `/${upstreamPath}`
+
+  return {
+    targetOrigin: `${protocol}://${host}`,
+    upstreamPath,
+  }
+}
+
+/**
+ * @returns {import('vite').Plugin}
+ */
+export function customProxyPlugin() {
+  return {
+    name: 'storyforge-custom-proxy',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url || ''
+        if (!url.startsWith(CUSTOM_PROXY_PREFIX)) {
+          next()
+          return
+        }
+
+        const parsed = parseCustomProxyPath(url)
+        if (!parsed) {
+          res.statusCode = 400
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+          res.end(
+            'Invalid custom-proxy path. Expected /custom-proxy/https/host/v1/...',
+          )
+          return
+        }
+
+        const targetUrl = new URL(parsed.upstreamPath, parsed.targetOrigin)
+        const isHttps = targetUrl.protocol === 'https:'
+        const lib = isHttps ? https : http
+
+        /** @type {import('node:http').OutgoingHttpHeaders} */
+        const headers = { ...req.headers }
+        headers.host = targetUrl.host
+        delete headers.origin
+        delete headers.referer
+        delete headers.connection
+
+        const proxyReq = lib.request(
+          {
+            protocol: targetUrl.protocol,
+            hostname: targetUrl.hostname,
+            port: targetUrl.port || (isHttps ? 443 : 80),
+            path: `${targetUrl.pathname}${targetUrl.search}`,
+            method: req.method,
+            headers,
+            timeout: 120_000,
+          },
+          (proxyRes) => {
+            res.statusCode = proxyRes.statusCode || 502
+            for (const [key, value] of Object.entries(proxyRes.headers)) {
+              if (value === undefined) continue
+              const lk = key.toLowerCase()
+              if (lk === 'transfer-encoding' || lk === 'connection') continue
+              res.setHeader(key, value)
+            }
+            proxyRes.pipe(res)
+          },
+        )
+
+        proxyReq.on('timeout', () => {
+          proxyReq.destroy()
+          if (!res.headersSent) {
+            res.statusCode = 504
+            res.end('Upstream timeout')
+          }
+        })
+
+        proxyReq.on('error', (err) => {
+          console.error('[custom-proxy]', targetUrl.href, err.message)
+          if (!res.headersSent) {
+            res.statusCode = 502
+            res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+            res.end(`custom-proxy upstream error: ${err.message}`)
+          } else {
+            res.end()
+          }
+        })
+
+        req.pipe(proxyReq)
+      })
+    },
+  }
+}

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -5,6 +5,11 @@ import EmbeddingConfigCard from './EmbeddingConfigCard'
 import type { AIProvider } from '../../lib/types'
 import { PROVIDER_MODELS } from '../../lib/types'
 import { isAIConfigReady } from '../../lib/ai/config-readiness'
+import {
+  fromCustomProxyBaseUrl,
+  isCustomProxyBaseUrl,
+  toCustomProxyBaseUrl,
+} from '../../lib/ai/custom-proxy'
 import { getLogs, subscribeLogs, clearLogs, formatLog } from '../../lib/ai/logger'
 import { applyStoryForgeTheme, resolveStoryForgeTheme, THEME_OPTIONS, type StoryForgeTheme } from '../../lib/theme'
 import { useDialog } from '../shared/Dialog'
@@ -27,7 +32,7 @@ export const PROVIDER_OPTIONS: { value: AIProvider; label: string; cors: boolean
   { value: 'longcat', label: 'LongCat（美团）', cors: false, hint: '获取 Key: longcat.chat 平台控制台；OpenAI 兼容接口（若浏览器直连 CORS 失败可切换本地代理）' },
   { value: 'opencode', label: 'OpenCode Go（月付）', cors: false, hint: '获取 Key: opencode.ai → Zen → Go API Key（需点击下方「切换到本地代理」）' },
   { value: 'ollama', label: '本地模型 (Ollama / LM Studio 等)', cors: true, hint: '本地 OpenAI-compatible /v1 接口；Ollama 常用 http://localhost:11434/v1，LM Studio 常用 http://localhost:1234/v1；通常无需 API Key。' },
-  { value: 'custom', label: '自定义', cors: true, hint: '填写任何兼容 OpenAI 格式的 API' },
+  { value: 'custom', label: '自定义', cors: true, hint: '填写任何兼容 OpenAI 格式的 API。若浏览器报 CORS/网络错误，本地开发可点「切换到本地代理」（仅 npm run dev）' },
 ]
 
 export default function AIConfigPanel() {
@@ -309,6 +314,45 @@ export default function AIConfigPanel() {
                   </div>
                 )
               })()}
+              {config.provider === 'custom' && import.meta.env.DEV && (() => {
+                const isProxy = isCustomProxyBaseUrl(config.baseUrl)
+                let canToggle = isProxy
+                if (!canToggle) {
+                  try {
+                    const u = new URL(config.baseUrl)
+                    canToggle = u.protocol === 'http:' || u.protocol === 'https:'
+                  } catch {
+                    canToggle = false
+                  }
+                }
+                if (!canToggle) return null
+                return (
+                  <div className="mt-1.5 space-y-1">
+                    <div className="flex flex-wrap gap-2">
+                      {!isProxy ? (
+                        <button
+                          onClick={() => setConfig({ baseUrl: toCustomProxyBaseUrl(config.baseUrl) })}
+                          className="text-xs px-2 py-1 rounded bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 transition-colors"
+                        >
+                          🔄 切换到本地代理
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => setConfig({ baseUrl: fromCustomProxyBaseUrl(config.baseUrl) })}
+                          className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 transition-colors"
+                        >
+                          🔗 恢复直连
+                        </button>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-amber-500/90">
+                      {isProxy
+                        ? '当前经 Vite 本地代理转发（仅 npm run dev）。'
+                        : '网关不支持浏览器 CORS 时点此；请求经本机 Vite 转发，仅开发环境有效。'}
+                    </p>
+                  </div>
+                )
+              })()}
             </div>
             <div>
               <label className="block text-sm text-text-secondary mb-1.5">模型</label>
@@ -462,12 +506,13 @@ export default function AIConfigPanel() {
               </div>
             )}
             {/* CORS 错误提示 */}
-            {testResult && !testResult.ok && config.provider === 'deepseek' &&
+            {testResult && !testResult.ok &&
+              (config.provider === 'deepseek' || config.provider === 'custom') &&
               (testResult.message.includes('CORS') || testResult.message.includes('网络错误')) && (
               <p className="text-xs text-amber-400 px-1">
                 {import.meta.env.DEV
-                  ? '💡 本地运行时，可点击「切换到本地代理」解决此问题'
-                  : '💡 建议改用 Gemini（支持浏览器直调）或在本地运行此工具'}
+                  ? '💡 本地运行时，可点击 Base URL 下方「切换到本地代理」解决 CORS/网络错误（自定义网关与 DeepSeek 等均适用）'
+                  : '💡 该地址可能不支持浏览器直连（CORS）。请改用支持 CORS 的接口、自建中转，或在本地 npm run dev 下使用「本地代理」'}
               </p>
             )}
           </div>

--- a/src/lib/ai/custom-proxy.ts
+++ b/src/lib/ai/custom-proxy.ts
@@ -1,0 +1,88 @@
+/**
+ * 本地开发用：把任意 OpenAI 兼容 Base URL 编成同源路径，
+ * 交给 Vite `/custom-proxy` 中间件转发，绕过浏览器 CORS。
+ *
+ * 例：https://api.example.com/v1 → /custom-proxy/https/api.example.com/v1
+ * 仅 `npm run dev` 有效；生产静态部署没有该代理。
+ */
+
+export const CUSTOM_PROXY_PREFIX = '/custom-proxy'
+
+export interface ParsedCustomProxyPath {
+  /** 上游 origin，如 https://api.example.com */
+  targetOrigin: string
+  /** 转发给上游的 path+query，如 /v1/chat/completions */
+  upstreamPath: string
+}
+
+/** 当前 Base URL 是否已是本地自定义代理路径 */
+export function isCustomProxyBaseUrl(baseUrl: string): boolean {
+  const raw = (baseUrl || '').trim()
+  return raw === CUSTOM_PROXY_PREFIX || raw.startsWith(`${CUSTOM_PROXY_PREFIX}/`)
+}
+
+/**
+ * 直连 Base URL → 本地代理 Base URL。
+ * 非法 / 相对路径原样返回（无法代理）。
+ */
+export function toCustomProxyBaseUrl(directBaseUrl: string): string {
+  const input = (directBaseUrl || '').trim().replace(/\/+$/, '')
+  if (!input || isCustomProxyBaseUrl(input)) return input
+
+  let url: URL
+  try {
+    url = new URL(input)
+  } catch {
+    return input
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return input
+
+  const protocol = url.protocol.replace(':', '')
+  const path = url.pathname.replace(/\/+$/, '')
+  return `${CUSTOM_PROXY_PREFIX}/${protocol}/${url.host}${path}`
+}
+
+/**
+ * 本地代理 Base URL → 直连 Base URL。
+ * 非代理路径原样返回。
+ */
+export function fromCustomProxyBaseUrl(proxyBaseUrl: string): string {
+  const input = (proxyBaseUrl || '').trim().replace(/\/+$/, '')
+  if (!isCustomProxyBaseUrl(input)) return input
+
+  const rest = input.slice(CUSTOM_PROXY_PREFIX.length).replace(/^\//, '')
+  const match = rest.match(/^(https?)\/([^/]+)(.*)$/i)
+  if (!match) return input
+
+  const protocol = match[1].toLowerCase()
+  const host = match[2]
+  const path = (match[3] || '').replace(/\/+$/, '')
+  return `${protocol}://${host}${path}`
+}
+
+/**
+ * 解析发往 Vite 的完整请求 path（含 /custom-proxy 前缀）。
+ * 供 dev 中间件转发使用。
+ */
+export function parseCustomProxyPath(requestPath: string): ParsedCustomProxyPath | null {
+  const raw = (requestPath || '').trim()
+  if (!raw.startsWith(CUSTOM_PROXY_PREFIX)) return null
+
+  const qIndex = raw.indexOf('?')
+  const pathOnly = qIndex >= 0 ? raw.slice(0, qIndex) : raw
+  const query = qIndex >= 0 ? raw.slice(qIndex) : ''
+
+  const rest = pathOnly.slice(CUSTOM_PROXY_PREFIX.length).replace(/^\//, '')
+  const match = rest.match(/^(https?)\/([^/]+)(.*)$/i)
+  if (!match) return null
+
+  const protocol = match[1].toLowerCase()
+  const host = match[2]
+  const upstreamPath = `${match[3] || '/'}${query}` || `/${query}`
+
+  return {
+    targetOrigin: `${protocol}://${host}`,
+    upstreamPath: upstreamPath.startsWith('/') ? upstreamPath : `/${upstreamPath}`,
+  }
+}

--- a/tests/regression/R-custom-proxy-local.test.ts
+++ b/tests/regression/R-custom-proxy-local.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CUSTOM_PROXY_PREFIX,
+  fromCustomProxyBaseUrl,
+  isCustomProxyBaseUrl,
+  parseCustomProxyPath,
+  toCustomProxyBaseUrl,
+} from '../../src/lib/ai/custom-proxy'
+import { buildOpenAIEndpoint } from '../../src/lib/ai/openai-endpoint'
+
+describe('R-custom-proxy-local · 自定义网关本地代理', () => {
+  it('直连 Base URL 与本地代理路径可往返', () => {
+    const direct = 'https://api.example.com/v1'
+    const proxy = toCustomProxyBaseUrl(direct)
+    expect(proxy).toBe('/custom-proxy/https/api.example.com/v1')
+    expect(isCustomProxyBaseUrl(proxy)).toBe(true)
+    expect(fromCustomProxyBaseUrl(proxy)).toBe(direct)
+  })
+
+  it('已是代理路径时 toCustomProxyBaseUrl 幂等', () => {
+    const proxy = '/custom-proxy/https/api.example.com/v1'
+    expect(toCustomProxyBaseUrl(proxy)).toBe(proxy)
+  })
+
+  it('非法 / 相对路径不硬改', () => {
+    expect(toCustomProxyBaseUrl('/deepseek-proxy/v1')).toBe('/deepseek-proxy/v1')
+    expect(toCustomProxyBaseUrl('not-a-url')).toBe('not-a-url')
+  })
+
+  it('proxy Base URL 拼出正确 chat/completions 路径', () => {
+    const proxyBase = toCustomProxyBaseUrl('https://api.example.com/v1')
+    expect(buildOpenAIEndpoint(proxyBase, 'chat/completions')).toBe(
+      '/custom-proxy/https/api.example.com/v1/chat/completions',
+    )
+  })
+
+  it('parseCustomProxyPath 解析上游 origin 与 path', () => {
+    const parsed = parseCustomProxyPath(
+      `${CUSTOM_PROXY_PREFIX}/https/api.example.com/v1/chat/completions`,
+    )
+    expect(parsed).toEqual({
+      targetOrigin: 'https://api.example.com',
+      upstreamPath: '/v1/chat/completions',
+    })
+  })
+
+  it('parseCustomProxyPath 保留 query', () => {
+    const parsed = parseCustomProxyPath(
+      '/custom-proxy/http/localhost:11434/v1/models?foo=1',
+    )
+    expect(parsed).toEqual({
+      targetOrigin: 'http://localhost:11434',
+      upstreamPath: '/v1/models?foo=1',
+    })
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import { customProxyPlugin } from './scripts/vite-custom-proxy-plugin.mjs'
 
 export default defineConfig({
   plugins: [
     react(),
+    customProxyPlugin(),
     VitePWA({
       injectRegister: null,
       registerType: 'autoUpdate',
@@ -141,6 +143,7 @@ export default defineConfig({
         rewrite: (path: string) => path.replace(/^\/glm-proxy/, ''),
         secure: true,
       },
+      // 自定义网关本地代理见 customProxyPlugin（scripts/vite-custom-proxy-plugin.mjs）
     },
   },
   build: {


### PR DESCRIPTION
## 问题

部分自定义 OpenAI 兼容接口在浏览器中会因 CORS 导致「测试连接」失败（curl / 服务端调用正常）。

Closes #19

## 方案

在 `npm run dev` 下增加自定义 Base URL 的本地代理：

- 将 `https://host/v1` 编码为同源路径 `/custom-proxy/https/host/v1`
- 由 Vite 开发服务器转发到上游
- 设置页「自定义」提供商可一键切换本地代理 / 恢复直连

## 说明

- 仅开发环境有效，生产静态部署不包含该代理
- 不改变 chat 请求体格式，只改变浏览器访问的 URL

## 测试

- [x] `npx vitest run tests/regression/R-custom-proxy-local.test.ts`
- [x] 自定义网关直连 CORS 失败 → 切换本地代理后测试连接成功
- [x] 「恢复直连」可还原原 Base URL

| 该 PR 由 AI 生成, 人工测试审核.
