### PR TITLE
feat(settings): 刷新远程模型列表并支持可输入下拉

### DIFF
--- a/scripts/vite-custom-proxy-plugin.mjs
+++ b/scripts/vite-custom-proxy-plugin.mjs
@@ -1,0 +1,120 @@
+/**
+ * Vite 开发插件：/custom-proxy/{http|https}/{host}{path}
+ * 动态转发到任意 OpenAI 兼容上游，绕过浏览器 CORS。
+ * 仅 dev server 有效。
+ *
+ * 解析规则与 src/lib/ai/custom-proxy.ts 保持一致（此处内联，避免 .mjs 直接 import .ts）。
+ */
+import http from 'node:http'
+import https from 'node:https'
+
+const CUSTOM_PROXY_PREFIX = '/custom-proxy'
+
+/**
+ * @param {string} requestPath
+ * @returns {{ targetOrigin: string, upstreamPath: string } | null}
+ */
+function parseCustomProxyPath(requestPath) {
+  const raw = (requestPath || '').trim()
+  if (!raw.startsWith(CUSTOM_PROXY_PREFIX)) return null
+
+  const qIndex = raw.indexOf('?')
+  const pathOnly = qIndex >= 0 ? raw.slice(0, qIndex) : raw
+  const query = qIndex >= 0 ? raw.slice(qIndex) : ''
+
+  const rest = pathOnly.slice(CUSTOM_PROXY_PREFIX.length).replace(/^\//, '')
+  const match = rest.match(/^(https?)\/([^/]+)(.*)$/i)
+  if (!match) return null
+
+  const protocol = match[1].toLowerCase()
+  const host = match[2]
+  let upstreamPath = `${match[3] || '/'}${query}`
+  if (!upstreamPath.startsWith('/')) upstreamPath = `/${upstreamPath}`
+
+  return {
+    targetOrigin: `${protocol}://${host}`,
+    upstreamPath,
+  }
+}
+
+/**
+ * @returns {import('vite').Plugin}
+ */
+export function customProxyPlugin() {
+  return {
+    name: 'storyforge-custom-proxy',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const url = req.url || ''
+        if (!url.startsWith(CUSTOM_PROXY_PREFIX)) {
+          next()
+          return
+        }
+
+        const parsed = parseCustomProxyPath(url)
+        if (!parsed) {
+          res.statusCode = 400
+          res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+          res.end(
+            'Invalid custom-proxy path. Expected /custom-proxy/https/host/v1/...',
+          )
+          return
+        }
+
+        const targetUrl = new URL(parsed.upstreamPath, parsed.targetOrigin)
+        const isHttps = targetUrl.protocol === 'https:'
+        const lib = isHttps ? https : http
+
+        /** @type {import('node:http').OutgoingHttpHeaders} */
+        const headers = { ...req.headers }
+        headers.host = targetUrl.host
+        delete headers.origin
+        delete headers.referer
+        delete headers.connection
+
+        const proxyReq = lib.request(
+          {
+            protocol: targetUrl.protocol,
+            hostname: targetUrl.hostname,
+            port: targetUrl.port || (isHttps ? 443 : 80),
+            path: `${targetUrl.pathname}${targetUrl.search}`,
+            method: req.method,
+            headers,
+            timeout: 120_000,
+          },
+          (proxyRes) => {
+            res.statusCode = proxyRes.statusCode || 502
+            for (const [key, value] of Object.entries(proxyRes.headers)) {
+              if (value === undefined) continue
+              const lk = key.toLowerCase()
+              if (lk === 'transfer-encoding' || lk === 'connection') continue
+              res.setHeader(key, value)
+            }
+            proxyRes.pipe(res)
+          },
+        )
+
+        proxyReq.on('timeout', () => {
+          proxyReq.destroy()
+          if (!res.headersSent) {
+            res.statusCode = 504
+            res.end('Upstream timeout')
+          }
+        })
+
+        proxyReq.on('error', (err) => {
+          console.error('[custom-proxy]', targetUrl.href, err.message)
+          if (!res.headersSent) {
+            res.statusCode = 502
+            res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+            res.end(`custom-proxy upstream error: ${err.message}`)
+          } else {
+            res.end()
+          }
+        })
+
+        req.pipe(proxyReq)
+      })
+    },
+  }
+}

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useSyncExternalStore } from 'react'
-import { Wifi, WifiOff, Eye, EyeOff, CheckCircle, Trash2, ScrollText } from 'lucide-react'
+import { useState, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
+import { Wifi, WifiOff, Eye, EyeOff, CheckCircle, Trash2, ScrollText, RefreshCw, ChevronDown } from 'lucide-react'
 import { useAIConfigStore, type TestResult } from '../../stores/ai-config'
 import EmbeddingConfigCard from './EmbeddingConfigCard'
 import type { AIProvider } from '../../lib/types'
@@ -10,6 +10,8 @@ import {
   isCustomProxyBaseUrl,
   toCustomProxyBaseUrl,
 } from '../../lib/ai/custom-proxy'
+import { listOpenAIModels } from '../../lib/ai/list-models'
+import { normalizeOpenAIBaseUrl } from '../../lib/ai/openai-endpoint'
 import { getLogs, subscribeLogs, clearLogs, formatLog } from '../../lib/ai/logger'
 import { applyStoryForgeTheme, resolveStoryForgeTheme, THEME_OPTIONS, type StoryForgeTheme } from '../../lib/theme'
 import { useDialog } from '../shared/Dialog'
@@ -46,6 +48,12 @@ export default function AIConfigPanel() {
   const [showLogs, setShowLogs] = useState(false)
   const [savingPreset, setSavingPreset] = useState(false)
   const [presetName, setPresetName] = useState('')
+  const [fetchedModels, setFetchedModels] = useState<string[]>([])
+  const [hasFetchedModels, setHasFetchedModels] = useState(false)
+  const [refreshingModels, setRefreshingModels] = useState(false)
+  const [modelListError, setModelListError] = useState('')
+  const [modelMenuOpen, setModelMenuOpen] = useState(false)
+  const modelComboboxRef = useRef<HTMLDivElement>(null)
   const [currentTheme, setCurrentTheme] = useState<StoryForgeTheme>(() =>
     resolveStoryForgeTheme(localStorage.getItem('storyforge-theme')),
   )
@@ -71,6 +79,35 @@ export default function AIConfigPanel() {
       setTestResult(result)
     } finally {
       setTesting(false)
+    }
+  }
+
+  const handleRefreshModels = async () => {
+    setRefreshingModels(true)
+    setModelListError('')
+    try {
+      const normalized = normalizeOpenAIBaseUrl(config.baseUrl)
+      if (normalized.changed) setConfig({ baseUrl: normalized.baseUrl })
+      const result = await listOpenAIModels({
+        baseUrl: normalized.baseUrl,
+        apiKey: config.apiKey,
+        provider: config.provider,
+        model: config.model,
+      })
+      setHasFetchedModels(true)
+      if (result.ok) {
+        setFetchedModels(result.models)
+        if (result.models.length === 0) {
+          setModelListError('未返回模型，可手动填写模型名')
+        } else {
+          setModelMenuOpen(true)
+        }
+      } else {
+        setFetchedModels([])
+        setModelListError(result.message)
+      }
+    } finally {
+      setRefreshingModels(false)
     }
   }
 
@@ -102,6 +139,37 @@ export default function AIConfigPanel() {
   useEffect(() => {
     setTestResult(null)
   }, [config.provider])
+
+  // 换 provider / Base URL 后丢弃内存中的远程模型列表
+  useEffect(() => {
+    setFetchedModels([])
+    setHasFetchedModels(false)
+    setModelListError('')
+    setModelMenuOpen(false)
+  }, [config.provider, config.baseUrl])
+
+  // 模型 combobox：点击外部关闭
+  useEffect(() => {
+    if (!modelMenuOpen) return
+    const onPointerDown = (e: MouseEvent) => {
+      if (!modelComboboxRef.current?.contains(e.target as Node)) {
+        setModelMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    return () => document.removeEventListener('mousedown', onPointerDown)
+  }, [modelMenuOpen])
+
+  const staticModels = PROVIDER_MODELS[config.provider]?.map((m) => m.value) ?? []
+  const modelCatalog = hasFetchedModels ? fetchedModels : staticModels
+  const modelFilter = config.model.trim().toLowerCase()
+  const modelMenuOptions = useMemo(() => {
+    if (!modelFilter) return modelCatalog
+    return modelCatalog.filter((id) => id.toLowerCase().includes(modelFilter))
+  }, [modelCatalog, modelFilter])
+  const selectedStaticDesc = !hasFetchedModels
+    ? PROVIDER_MODELS[config.provider]?.find((m) => m.value === config.model)?.desc
+    : undefined
 
   return (
     <div className="max-w-2xl">
@@ -355,42 +423,106 @@ export default function AIConfigPanel() {
               })()}
             </div>
             <div>
-              <label className="block text-sm text-text-secondary mb-1.5">模型</label>
-              {PROVIDER_MODELS[config.provider] ? (
-                <>
-                  <select
-                    value={config.model}
-                    onChange={(e) => setConfig({ model: e.target.value })}
-                    className="w-full px-3 py-2 bg-bg-base border border-border rounded-lg text-text-primary text-sm focus:outline-none focus:border-accent transition-colors"
-                  >
-                    {PROVIDER_MODELS[config.provider].map((m) => (
-                      <option key={m.value} value={m.value}>
-                        {m.value}
-                      </option>
-                    ))}
-                  </select>
-                  {(() => {
-                    const selected = PROVIDER_MODELS[config.provider]?.find((m) => m.value === config.model)
-                    return selected?.desc ? (
-                      <p className="mt-1 text-xs text-text-muted">{selected.desc}</p>
-                    ) : null
-                  })()}
-                  {/* 自定义模型名：列表里没有的模型可手动输入 */}
+              <div className="mb-1.5 flex items-center justify-between gap-2">
+                <label className="block text-sm text-text-secondary">模型</label>
+                <button
+                  type="button"
+                  onClick={() => { void handleRefreshModels() }}
+                  disabled={refreshingModels || !isAIConfigReady(config)}
+                  title="从当前 Base URL 拉取 /models 列表"
+                  className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-accent hover:bg-accent/10 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <RefreshCw className={`h-3.5 w-3.5 ${refreshingModels ? 'animate-spin' : ''}`} />
+                  {refreshingModels ? '刷新中' : '刷新模型'}
+                </button>
+              </div>
+
+              {/* 一体 combobox：可手输 + 下拉选列表项 */}
+              <div ref={modelComboboxRef} className="relative">
+                <div className="flex items-stretch rounded-lg border border-border bg-bg-base focus-within:border-accent transition-colors">
                   <input
                     type="text"
                     value={config.model}
-                    onChange={(e) => setConfig({ model: e.target.value })}
-                    placeholder="或手动输入模型名（列表中没有的型号）"
-                    className="mt-1.5 w-full px-3 py-1.5 bg-bg-base border border-border rounded-lg text-text-primary text-xs focus:outline-none focus:border-accent transition-colors"
+                    onChange={(e) => {
+                      setConfig({ model: e.target.value })
+                      if (modelCatalog.length > 0) setModelMenuOpen(true)
+                    }}
+                    onFocus={() => {
+                      if (modelCatalog.length > 0) setModelMenuOpen(true)
+                    }}
+                    placeholder={
+                      hasFetchedModels
+                        ? '输入或从列表选择模型'
+                        : modelCatalog.length > 0
+                          ? '输入或从列表选择模型'
+                          : '输入模型名，或点刷新获取列表'
+                    }
+                    aria-autocomplete="list"
+                    aria-expanded={modelMenuOpen}
+                    aria-controls="ai-model-combobox-list"
+                    className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-text-primary placeholder-text-muted focus:outline-none"
                   />
-                </>
-              ) : (
-                <input
-                  type="text"
-                  value={config.model}
-                  onChange={(e) => setConfig({ model: e.target.value })}
-                  className="w-full px-3 py-2 bg-bg-base border border-border rounded-lg text-text-primary text-sm focus:outline-none focus:border-accent transition-colors"
-                />
+                  <button
+                    type="button"
+                    onClick={() => setModelMenuOpen((open) => !open)}
+                    disabled={modelCatalog.length === 0 && !hasFetchedModels}
+                    title={modelCatalog.length === 0 ? '暂无列表，可手输或先刷新' : '展开模型列表'}
+                    className="flex items-center px-2.5 text-text-muted hover:text-text-secondary disabled:cursor-not-allowed disabled:opacity-40"
+                    aria-label="展开模型列表"
+                  >
+                    <ChevronDown className={`h-4 w-4 transition-transform ${modelMenuOpen ? 'rotate-180' : ''}`} />
+                  </button>
+                </div>
+
+                {modelMenuOpen && (
+                  <div
+                    id="ai-model-combobox-list"
+                    role="listbox"
+                    className="absolute z-30 mt-1 max-h-52 w-full overflow-y-auto rounded-lg border border-border bg-bg-surface shadow-lg"
+                  >
+                    {hasFetchedModels && fetchedModels.length === 0 && (
+                      <p className="px-3 py-2 text-xs text-text-muted">未返回模型，可直接在上方输入</p>
+                    )}
+                    {!hasFetchedModels && modelCatalog.length === 0 && (
+                      <p className="px-3 py-2 text-xs text-text-muted">点击「刷新模型」拉取列表，或直接输入</p>
+                    )}
+                    {modelMenuOptions.length === 0 && modelCatalog.length > 0 && (
+                      <p className="px-3 py-2 text-xs text-text-muted">无匹配项，可继续手输当前内容</p>
+                    )}
+                    {modelMenuOptions.map((model) => (
+                      <button
+                        key={model}
+                        type="button"
+                        role="option"
+                        aria-selected={config.model === model}
+                        onClick={() => {
+                          setConfig({ model })
+                          setModelMenuOpen(false)
+                        }}
+                        className={`block w-full px-3 py-2 text-left text-sm transition-colors hover:bg-accent/10 ${
+                          config.model === model ? 'bg-accent/15 text-accent' : 'text-text-primary'
+                        }`}
+                      >
+                        {model}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {selectedStaticDesc && (
+                <p className="mt-1 text-xs text-text-muted">{selectedStaticDesc}</p>
+              )}
+              {modelListError && (
+                <p className="mt-1 text-[11px] text-amber-400">{modelListError}</p>
+              )}
+              {hasFetchedModels && !modelListError && (
+                <p className="mt-1 text-[11px] text-text-muted">
+                  已加载 {fetchedModels.length} 个远程模型；可下拉选择，也可直接改输入框。
+                </p>
+              )}
+              {config.provider === 'ollama' && (
+                <p className="mt-1 text-[11px] text-text-muted">未安装的模型请先在 Ollama 拉取，完成后再点刷新。</p>
               )}
             </div>
           </div>

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -5,6 +5,11 @@ import EmbeddingConfigCard from './EmbeddingConfigCard'
 import type { AIProvider } from '../../lib/types'
 import { PROVIDER_MODELS } from '../../lib/types'
 import { isAIConfigReady } from '../../lib/ai/config-readiness'
+import {
+  fromCustomProxyBaseUrl,
+  isCustomProxyBaseUrl,
+  toCustomProxyBaseUrl,
+} from '../../lib/ai/custom-proxy'
 import { getLogs, subscribeLogs, clearLogs, formatLog } from '../../lib/ai/logger'
 import { applyStoryForgeTheme, resolveStoryForgeTheme, THEME_OPTIONS, type StoryForgeTheme } from '../../lib/theme'
 import { useDialog } from '../shared/Dialog'
@@ -27,7 +32,7 @@ export const PROVIDER_OPTIONS: { value: AIProvider; label: string; cors: boolean
   { value: 'longcat', label: 'LongCat（美团）', cors: false, hint: '获取 Key: longcat.chat 平台控制台；OpenAI 兼容接口（若浏览器直连 CORS 失败可切换本地代理）' },
   { value: 'opencode', label: 'OpenCode Go（月付）', cors: false, hint: '获取 Key: opencode.ai → Zen → Go API Key（需点击下方「切换到本地代理」）' },
   { value: 'ollama', label: '本地模型 (Ollama / LM Studio 等)', cors: true, hint: '本地 OpenAI-compatible /v1 接口；Ollama 常用 http://localhost:11434/v1，LM Studio 常用 http://localhost:1234/v1；通常无需 API Key。' },
-  { value: 'custom', label: '自定义', cors: true, hint: '填写任何兼容 OpenAI 格式的 API' },
+  { value: 'custom', label: '自定义', cors: true, hint: '填写任何兼容 OpenAI 格式的 API。若浏览器报 CORS/网络错误，本地开发可点「切换到本地代理」（仅 npm run dev）' },
 ]
 
 export default function AIConfigPanel() {
@@ -309,6 +314,45 @@ export default function AIConfigPanel() {
                   </div>
                 )
               })()}
+              {config.provider === 'custom' && import.meta.env.DEV && (() => {
+                const isProxy = isCustomProxyBaseUrl(config.baseUrl)
+                let canToggle = isProxy
+                if (!canToggle) {
+                  try {
+                    const u = new URL(config.baseUrl)
+                    canToggle = u.protocol === 'http:' || u.protocol === 'https:'
+                  } catch {
+                    canToggle = false
+                  }
+                }
+                if (!canToggle) return null
+                return (
+                  <div className="mt-1.5 space-y-1">
+                    <div className="flex flex-wrap gap-2">
+                      {!isProxy ? (
+                        <button
+                          onClick={() => setConfig({ baseUrl: toCustomProxyBaseUrl(config.baseUrl) })}
+                          className="text-xs px-2 py-1 rounded bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 transition-colors"
+                        >
+                          🔄 切换到本地代理
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => setConfig({ baseUrl: fromCustomProxyBaseUrl(config.baseUrl) })}
+                          className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 transition-colors"
+                        >
+                          🔗 恢复直连
+                        </button>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-amber-500/90">
+                      {isProxy
+                        ? '当前经 Vite 本地代理转发（仅 npm run dev）。'
+                        : '网关不支持浏览器 CORS 时点此；请求经本机 Vite 转发，仅开发环境有效。'}
+                    </p>
+                  </div>
+                )
+              })()}
             </div>
             <div>
               <label className="block text-sm text-text-secondary mb-1.5">模型</label>
@@ -462,12 +506,13 @@ export default function AIConfigPanel() {
               </div>
             )}
             {/* CORS 错误提示 */}
-            {testResult && !testResult.ok && config.provider === 'deepseek' &&
+            {testResult && !testResult.ok &&
+              (config.provider === 'deepseek' || config.provider === 'custom') &&
               (testResult.message.includes('CORS') || testResult.message.includes('网络错误')) && (
               <p className="text-xs text-amber-400 px-1">
                 {import.meta.env.DEV
-                  ? '💡 本地运行时，可点击「切换到本地代理」解决此问题'
-                  : '💡 建议改用 Gemini（支持浏览器直调）或在本地运行此工具'}
+                  ? '💡 本地运行时，可点击 Base URL 下方「切换到本地代理」解决 CORS/网络错误（自定义网关与 DeepSeek 等均适用）'
+                  : '💡 该地址可能不支持浏览器直连（CORS）。请改用支持 CORS 的接口、自建中转，或在本地 npm run dev 下使用「本地代理」'}
               </p>
             )}
           </div>

--- a/src/lib/ai/custom-proxy.ts
+++ b/src/lib/ai/custom-proxy.ts
@@ -1,0 +1,88 @@
+/**
+ * 本地开发用：把任意 OpenAI 兼容 Base URL 编成同源路径，
+ * 交给 Vite `/custom-proxy` 中间件转发，绕过浏览器 CORS。
+ *
+ * 例：https://api.example.com/v1 → /custom-proxy/https/api.example.com/v1
+ * 仅 `npm run dev` 有效；生产静态部署没有该代理。
+ */
+
+export const CUSTOM_PROXY_PREFIX = '/custom-proxy'
+
+export interface ParsedCustomProxyPath {
+  /** 上游 origin，如 https://api.example.com */
+  targetOrigin: string
+  /** 转发给上游的 path+query，如 /v1/chat/completions */
+  upstreamPath: string
+}
+
+/** 当前 Base URL 是否已是本地自定义代理路径 */
+export function isCustomProxyBaseUrl(baseUrl: string): boolean {
+  const raw = (baseUrl || '').trim()
+  return raw === CUSTOM_PROXY_PREFIX || raw.startsWith(`${CUSTOM_PROXY_PREFIX}/`)
+}
+
+/**
+ * 直连 Base URL → 本地代理 Base URL。
+ * 非法 / 相对路径原样返回（无法代理）。
+ */
+export function toCustomProxyBaseUrl(directBaseUrl: string): string {
+  const input = (directBaseUrl || '').trim().replace(/\/+$/, '')
+  if (!input || isCustomProxyBaseUrl(input)) return input
+
+  let url: URL
+  try {
+    url = new URL(input)
+  } catch {
+    return input
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return input
+
+  const protocol = url.protocol.replace(':', '')
+  const path = url.pathname.replace(/\/+$/, '')
+  return `${CUSTOM_PROXY_PREFIX}/${protocol}/${url.host}${path}`
+}
+
+/**
+ * 本地代理 Base URL → 直连 Base URL。
+ * 非代理路径原样返回。
+ */
+export function fromCustomProxyBaseUrl(proxyBaseUrl: string): string {
+  const input = (proxyBaseUrl || '').trim().replace(/\/+$/, '')
+  if (!isCustomProxyBaseUrl(input)) return input
+
+  const rest = input.slice(CUSTOM_PROXY_PREFIX.length).replace(/^\//, '')
+  const match = rest.match(/^(https?)\/([^/]+)(.*)$/i)
+  if (!match) return input
+
+  const protocol = match[1].toLowerCase()
+  const host = match[2]
+  const path = (match[3] || '').replace(/\/+$/, '')
+  return `${protocol}://${host}${path}`
+}
+
+/**
+ * 解析发往 Vite 的完整请求 path（含 /custom-proxy 前缀）。
+ * 供 dev 中间件转发使用。
+ */
+export function parseCustomProxyPath(requestPath: string): ParsedCustomProxyPath | null {
+  const raw = (requestPath || '').trim()
+  if (!raw.startsWith(CUSTOM_PROXY_PREFIX)) return null
+
+  const qIndex = raw.indexOf('?')
+  const pathOnly = qIndex >= 0 ? raw.slice(0, qIndex) : raw
+  const query = qIndex >= 0 ? raw.slice(qIndex) : ''
+
+  const rest = pathOnly.slice(CUSTOM_PROXY_PREFIX.length).replace(/^\//, '')
+  const match = rest.match(/^(https?)\/([^/]+)(.*)$/i)
+  if (!match) return null
+
+  const protocol = match[1].toLowerCase()
+  const host = match[2]
+  const upstreamPath = `${match[3] || '/'}${query}` || `/${query}`
+
+  return {
+    targetOrigin: `${protocol}://${host}`,
+    upstreamPath: upstreamPath.startsWith('/') ? upstreamPath : `/${upstreamPath}`,
+  }
+}

--- a/src/lib/ai/list-models.ts
+++ b/src/lib/ai/list-models.ts
@@ -1,0 +1,138 @@
+/**
+ * OpenAI-compatible model list helper.
+ * GET buildOpenAIEndpoint(baseUrl, 'models') — same base/proxy path as chat.
+ */
+import { buildOpenAIEndpoint } from './openai-endpoint'
+
+export type ListModelsConfig = {
+  baseUrl: string
+  apiKey: string
+  provider?: string
+  model?: string
+}
+
+export type ListModelsResult =
+  | { ok: true; models: string[] }
+  | { ok: false; message: string }
+
+const LIST_TIMEOUT_MS = 15_000
+
+/** Short, non-overconfident hint by status class (list /models only). */
+function chineseStatusHint(status: number): string {
+  if (status === 401 || status === 403) return '认证或权限失败'
+  if (status === 404) return '接口不存在'
+  if (status >= 500) return '服务端错误'
+  if (status === 429) return '请求过于频繁'
+  return ''
+}
+
+/**
+ * From OpenAI-like `{ data: Array }` extract unique non-empty string ids
+ * from each item's `id` or fallback `name`. Sort with localeCompare.
+ * Wrong shape → [].
+ */
+export function parseOpenAIModelsResponse(json: unknown): string[] {
+  if (!json || typeof json !== 'object') return []
+  const data = (json as { data?: unknown }).data
+  if (!Array.isArray(data)) return []
+
+  const seen = new Set<string>()
+  const out: string[] = []
+
+  for (const item of data) {
+    if (!item || typeof item !== 'object') continue
+    const rec = item as { id?: unknown; name?: unknown }
+    let id: string | null = null
+    if (typeof rec.id === 'string' && rec.id.trim()) {
+      id = rec.id.trim()
+    } else if (typeof rec.name === 'string' && rec.name.trim()) {
+      id = rec.name.trim()
+    }
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+
+  out.sort((a, b) => a.localeCompare(b))
+  return out
+}
+
+/**
+ * List models via OpenAI-compatible GET /models.
+ * Does not mutate config. Chinese-friendly errors on network/HTTP failure.
+ */
+export async function listOpenAIModels(
+  config: ListModelsConfig,
+): Promise<ListModelsResult> {
+  const url = buildOpenAIEndpoint(config.baseUrl, 'models')
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), LIST_TIMEOUT_MS)
+
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    if (config.apiKey) {
+      headers.Authorization = `Bearer ${config.apiKey}`
+    }
+
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      headers,
+    })
+
+    if (response.ok) {
+      let json: unknown
+      try {
+        json = await response.json()
+      } catch {
+        return { ok: true, models: [] }
+      }
+      return { ok: true, models: parseOpenAIModelsResponse(json) }
+    }
+
+    const status = response.status
+    let detail = ''
+    try {
+      const bodyText = await response.text()
+      try {
+        const errJson = JSON.parse(bodyText) as {
+          error?: { message?: string }
+          message?: string
+          error_msg?: string
+        }
+        if (errJson.error?.message) detail = errJson.error.message
+        else if (errJson.message) detail = errJson.message
+        else if (errJson.error_msg) detail = errJson.error_msg
+        else if (bodyText.length > 0 && bodyText.length < 200) detail = bodyText
+      } catch {
+        if (bodyText.length > 0 && bodyText.length < 200) detail = bodyText
+      }
+    } catch {
+      // ignore body read failures
+    }
+
+    const hint = chineseStatusHint(status)
+    // Always keep HTTP status in the final message (detail/hint may omit it).
+    const parts = [`HTTP ${status}`]
+    if (detail) parts.push(detail)
+    if (hint) parts.push(hint)
+    return { ok: false, message: parts.join(' · ') }
+  } catch (err: unknown) {
+    const error = err as Error
+    if (error.name === 'TypeError' && error.message.includes('Failed to fetch')) {
+      return {
+        ok: false,
+        message:
+          '网络错误 — 可能原因：1) 网络不通 2) 该平台不支持浏览器直接调用(CORS) 3) Base URL 错误',
+      }
+    }
+    if (error.name === 'AbortError') {
+      return { ok: false, message: '请求超时' }
+    }
+    return { ok: false, message: error.message || '未知错误' }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/tests/regression/R-custom-proxy-local.test.ts
+++ b/tests/regression/R-custom-proxy-local.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CUSTOM_PROXY_PREFIX,
+  fromCustomProxyBaseUrl,
+  isCustomProxyBaseUrl,
+  parseCustomProxyPath,
+  toCustomProxyBaseUrl,
+} from '../../src/lib/ai/custom-proxy'
+import { buildOpenAIEndpoint } from '../../src/lib/ai/openai-endpoint'
+
+describe('R-custom-proxy-local · 自定义网关本地代理', () => {
+  it('直连 Base URL 与本地代理路径可往返', () => {
+    const direct = 'https://api.example.com/v1'
+    const proxy = toCustomProxyBaseUrl(direct)
+    expect(proxy).toBe('/custom-proxy/https/api.example.com/v1')
+    expect(isCustomProxyBaseUrl(proxy)).toBe(true)
+    expect(fromCustomProxyBaseUrl(proxy)).toBe(direct)
+  })
+
+  it('已是代理路径时 toCustomProxyBaseUrl 幂等', () => {
+    const proxy = '/custom-proxy/https/api.example.com/v1'
+    expect(toCustomProxyBaseUrl(proxy)).toBe(proxy)
+  })
+
+  it('非法 / 相对路径不硬改', () => {
+    expect(toCustomProxyBaseUrl('/deepseek-proxy/v1')).toBe('/deepseek-proxy/v1')
+    expect(toCustomProxyBaseUrl('not-a-url')).toBe('not-a-url')
+  })
+
+  it('proxy Base URL 拼出正确 chat/completions 路径', () => {
+    const proxyBase = toCustomProxyBaseUrl('https://api.example.com/v1')
+    expect(buildOpenAIEndpoint(proxyBase, 'chat/completions')).toBe(
+      '/custom-proxy/https/api.example.com/v1/chat/completions',
+    )
+  })
+
+  it('parseCustomProxyPath 解析上游 origin 与 path', () => {
+    const parsed = parseCustomProxyPath(
+      `${CUSTOM_PROXY_PREFIX}/https/api.example.com/v1/chat/completions`,
+    )
+    expect(parsed).toEqual({
+      targetOrigin: 'https://api.example.com',
+      upstreamPath: '/v1/chat/completions',
+    })
+  })
+
+  it('parseCustomProxyPath 保留 query', () => {
+    const parsed = parseCustomProxyPath(
+      '/custom-proxy/http/localhost:11434/v1/models?foo=1',
+    )
+    expect(parsed).toEqual({
+      targetOrigin: 'http://localhost:11434',
+      upstreamPath: '/v1/models?foo=1',
+    })
+  })
+})

--- a/tests/regression/R-list-models.test.ts
+++ b/tests/regression/R-list-models.test.ts
@@ -1,0 +1,209 @@
+/**
+ * R-list-models · OpenAI-compatible GET /models helper
+ * Guards: URL build (incl. custom-proxy), parse id/name, empty/malformed, HTTP 401, auth header.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  listOpenAIModels,
+  parseOpenAIModelsResponse,
+} from '../../src/lib/ai/list-models'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('parseOpenAIModelsResponse', () => {
+  it('extracts unique non-empty ids (id preferred, name fallback) and sorts', () => {
+    const models = parseOpenAIModelsResponse({
+      data: [
+        { id: 'm1' },
+        { id: 'm2' },
+        { name: 'only-name' },
+        { id: 'm1' },
+        { id: '' },
+        { name: '  ' },
+        { id: 123 },
+        null,
+      ],
+    })
+    expect(models).toEqual(['m1', 'm2', 'only-name'].sort((a, b) => a.localeCompare(b)))
+  })
+
+  it('returns [] for empty data', () => {
+    expect(parseOpenAIModelsResponse({ data: [] })).toEqual([])
+  })
+
+  it('returns [] for missing data / wrong shape', () => {
+    expect(parseOpenAIModelsResponse({})).toEqual([])
+    expect(parseOpenAIModelsResponse(null)).toEqual([])
+    expect(parseOpenAIModelsResponse({ data: 'nope' })).toEqual([])
+    expect(parseOpenAIModelsResponse(undefined)).toEqual([])
+  })
+})
+
+describe('listOpenAIModels', () => {
+  it('GETs https://api.example.com/v1/models and parses sample payload', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [{ id: 'm1' }, { id: 'm2' }, { name: 'only-name' }],
+      }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await listOpenAIModels({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'sk-test',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.models).toEqual(
+      ['m1', 'm2', 'only-name'].sort((a, b) => a.localeCompare(b)),
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.example.com/v1/models')
+    expect(url.endsWith('/models')).toBe(true)
+    expect(init.method).toBe('GET')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer sk-test')
+  })
+
+  it('proxy base /custom-proxy/... maps to .../models', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: 'local-a' }] }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await listOpenAIModels({
+      baseUrl: '/custom-proxy/https/api.example.com/v1',
+      apiKey: '',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.models).toEqual(['local-a'])
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/custom-proxy/https/api.example.com/v1/models')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  it('HTTP 401 → ok false with Chinese-friendly message', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ error: { message: 'Invalid API key' } }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await listOpenAIModels({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'bad',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.message.length).toBeGreaterThan(0)
+    expect(result.message).toMatch(/HTTP 401/)
+    expect(result.message).toMatch(/Invalid API key|认证/i)
+    expect('models' in result).toBe(false)
+  })
+
+  it('Authorization header only when apiKey is non-empty', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await listOpenAIModels({ baseUrl: 'https://api.example.com/v1', apiKey: '' })
+    const headersEmpty = (fetchMock.mock.calls[0] as [string, RequestInit])[1]
+      .headers as Record<string, string>
+    expect(headersEmpty.Authorization).toBeUndefined()
+
+    await listOpenAIModels({ baseUrl: 'https://api.example.com/v1', apiKey: 'sk-x' })
+    const headersSet = (fetchMock.mock.calls[1] as [string, RequestInit])[1]
+      .headers as Record<string, string>
+    expect(headersSet.Authorization).toBe('Bearer sk-x')
+  })
+
+  it('empty data → ok true with empty models', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+      })),
+    )
+
+    const result = await listOpenAIModels({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'k',
+    })
+    expect(result).toEqual({ ok: true, models: [] })
+  })
+
+  it('missing data shape → ok true with empty models', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      })),
+    )
+
+    const result = await listOpenAIModels({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'k',
+    })
+    expect(result).toEqual({ ok: true, models: [] })
+  })
+
+  it('Failed to fetch TypeError → CORS/network Chinese message', async () => {
+    const err = new TypeError('Failed to fetch')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw err
+      }),
+    )
+
+    const result = await listOpenAIModels({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'k',
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.message).toMatch(/网络|CORS|Base URL/)
+  })
+
+  it('AbortError → 请求超时', async () => {
+    const err = new Error('aborted')
+    err.name = 'AbortError'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw err
+      }),
+    )
+
+    const result = await listOpenAIModels({
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'k',
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.message).toBe('请求超时')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import { customProxyPlugin } from './scripts/vite-custom-proxy-plugin.mjs'
 
 export default defineConfig({
   plugins: [
     react(),
+    customProxyPlugin(),
     VitePWA({
       injectRegister: null,
       registerType: 'autoUpdate',
@@ -141,6 +143,7 @@ export default defineConfig({
         rewrite: (path: string) => path.replace(/^\/glm-proxy/, ''),
         secure: true,
       },
+      // 自定义网关本地代理见 customProxyPlugin（scripts/vite-custom-proxy-plugin.mjs）
     },
   },
   build: {


### PR DESCRIPTION
## 动机

自定义 / 本地模型型号经常变化，手输容易出错，需要从接口拉取列表并支持点选。

## 改动

- 新增 `listOpenAIModels`：`GET /models`，解析模型 id，失败时错误信息带 HTTP 状态码
- 设置页模型字段改为可输入下拉（手输 / 过滤 / 点选一体）
- 提供「刷新模型」；未刷新时仍可用内置静态列表（如有）
- 切换提供商或 Base URL 时清空内存中的列表

## 依赖

基于 `features/custom-api-local-proxy`（自定义网关开发环境本地代理）。若该分支尚未合入 main，请将本 PR 的 base 设为该分支。

## 测试

- [x] `npx vitest run tests/regression/R-list-models.test.ts`
- [x] 刷新后可下拉选择模型并写入配置
- [x] 列表中没有的型号仍可直接手输
- [x] 刷新失败时提示错误且不覆盖当前模型名

| 该 PR 由 AI 生成, 人工测试审核.
