### PR TITLE
feat: 全局替换、设定AI问答与分块章纲n选一功能

### DIFF
--- a/src/components/editor/ChapterEditor.tsx
+++ b/src/components/editor/ChapterEditor.tsx
@@ -55,6 +55,7 @@ const OutlinePreview = lazy(() => import('../outline/OutlinePreview'))
 const ReviewPanel = lazy(() => import('./ReviewPanel'))
 const NotePanel = lazy(() => import('./NotePanel'))
 const ComparePolishPanel = lazy(() => import('./ComparePolishPanel'))
+const SettingLookupPanel = lazy(() => import('./SettingLookupPanel'))
 
 function LazyPanelFallback() {
   return <div className="rounded-lg border border-border bg-bg-surface p-4 text-sm text-text-muted">面板加载中...</div>
@@ -121,6 +122,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
   const [showOutlinePreview, setShowOutlinePreview] = useState(false)
   const [showReviewPanel, setShowReviewPanel] = useState(false)
   const [showNotePanel, setShowNotePanel] = useState(false)
+  const [showSettingsLookup, setShowSettingsLookup] = useState(false)
   const [compareSourceHtml, setCompareSourceHtml] = useState<string | null>(null)
   const [contextBudget, setContextBudget] = useState<ContextBudget | null>(null)
   const [planReconciliationCurrent, setPlanReconciliationCurrent] = useState(false)
@@ -924,6 +926,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
           showOutlinePreview={showOutlinePreview}
           showReviewPanel={showReviewPanel}
           showNotePanel={showNotePanel}
+          showSettingsLookup={showSettingsLookup}
           customInstruction={customInstruction}
           onGenerate={() => { void handleGenerate() }}
           onContinue={() => { void handleContinue() }}
@@ -937,6 +940,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
           onToggleOutlinePreview={() => setShowOutlinePreview(!showOutlinePreview)}
           onToggleReviewPanel={() => setShowReviewPanel(!showReviewPanel)}
           onToggleNotePanel={() => setShowNotePanel(!showNotePanel)}
+          onToggleSettingsLookup={() => setShowSettingsLookup(!showSettingsLookup)}
           onCustomInstructionChange={setCustomInstruction}
         />
       )}
@@ -1001,6 +1005,19 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
         <div className="mb-3">
           <Suspense fallback={<LazyPanelFallback />}>
             <NotePanel projectId={project.id!} chapterId={currentChapter?.id} onClose={() => setShowNotePanel(false)} />
+          </Suspense>
+        </div>
+      )}
+
+      {/* H4: 设定查询面板 */}
+      {showSettingsLookup && (
+        <div className="mb-3">
+          <Suspense fallback={<LazyPanelFallback />}>
+            <SettingLookupPanel
+              aiConfig={aiConfig}
+              projectId={project.id!}
+              onClose={() => setShowSettingsLookup(false)}
+            />
           </Suspense>
         </div>
       )}

--- a/src/components/editor/ChapterEditorToolbar.tsx
+++ b/src/components/editor/ChapterEditorToolbar.tsx
@@ -1,4 +1,4 @@
-import { BookOpenCheck, ClipboardList, ShieldCheck, StickyNote } from 'lucide-react'
+import { BookOpenCheck, ClipboardList, ShieldCheck, StickyNote, Search } from 'lucide-react'
 import { CInput } from '../shared/CompositionInput'
 
 interface Props {
@@ -13,6 +13,7 @@ interface Props {
   showOutlinePreview: boolean
   showReviewPanel: boolean
   showNotePanel: boolean
+  showSettingsLookup: boolean
   customInstruction: string
   onGenerate: () => void
   onContinue: () => void
@@ -26,6 +27,7 @@ interface Props {
   onToggleOutlinePreview: () => void
   onToggleReviewPanel: () => void
   onToggleNotePanel: () => void
+  onToggleSettingsLookup: () => void
   onCustomInstructionChange: (value: string) => void
 }
 
@@ -41,6 +43,7 @@ export default function ChapterEditorToolbar({
   showOutlinePreview,
   showReviewPanel,
   showNotePanel,
+  showSettingsLookup,
   customInstruction,
   onGenerate,
   onContinue,
@@ -54,6 +57,7 @@ export default function ChapterEditorToolbar({
   onToggleOutlinePreview,
   onToggleReviewPanel,
   onToggleNotePanel,
+  onToggleSettingsLookup,
   onCustomInstructionChange,
 }: Props) {
   return (
@@ -137,6 +141,17 @@ export default function ChapterEditorToolbar({
         }`}>
         <StickyNote className="w-3 h-3" />
         便签
+      </button>
+      <button onClick={onToggleSettingsLookup}
+        title="设定查询"
+        aria-pressed={showSettingsLookup}
+        className={`flex items-center gap-1 px-3 py-1.5 text-xs rounded-md transition-colors ${
+          showSettingsLookup
+            ? 'bg-purple-500/10 text-purple-400'
+            : 'bg-bg-elevated text-text-secondary hover:text-text-primary'
+        }`}>
+        <Search className="w-3 h-3" />
+        设定查询
       </button>
       <CInput value={customInstruction} onChange={event => onCustomInstructionChange(event.target.value)}
         placeholder="自定义指令..."

--- a/src/components/editor/SettingLookupPanel.tsx
+++ b/src/components/editor/SettingLookupPanel.tsx
@@ -1,0 +1,867 @@
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import { Search, X, BookOpen, Users, Scroll, Hash, Sparkles, Loader2, Send, FileText, Check } from 'lucide-react'
+import type { CodexEntry, BuiltInCodexKey } from '../../lib/types/codex'
+import type { Character } from '../../lib/types/character'
+import type { WorldRuleNodeDef } from '../../lib/types/world-rules'
+import { WORLD_RULE_TREE } from '../../lib/types/world-rules'
+import { parseFieldSchema, parseEntryFields } from '../../lib/types/codex'
+import { scoreCodexEntry } from '../../lib/codex/search'
+import { chat, streamChat } from '../../lib/ai/client'
+import type { AIConfig } from '../../lib/types'
+import { useCodexStore } from '../../stores/codex'
+import { useCharacterStore } from '../../stores/character'
+import { useWorldRulesStore } from '../../stores/world-rules'
+
+interface Props {
+  aiConfig: AIConfig
+  projectId: number
+  onClose: () => void
+}
+
+interface SearchResult {
+  type: 'codex' | 'character' | 'worldRule'
+  id: number | string
+  name: string
+  summary: string
+  category?: string
+  icon?: string
+  score: number
+  data: CodexEntry | Character | { node: WorldRuleNodeDef; entry?: { historicalAnchors: string; fictionalAdaptations: string; priority: string } }
+}
+
+interface QAMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+interface ExtractedSetting {
+  id: string
+  name: string
+  category: string
+  categoryKey: BuiltInCodexKey
+  summary: string
+  fields: Record<string, string>
+  existingEntryId?: number
+}
+
+const STORAGE_KEY = 'storyforge-setting-qa-messages'
+
+export default function SettingLookupPanel({
+  aiConfig,
+  projectId,
+  onClose,
+}: Props) {
+  const [mode, setMode] = useState<'search' | 'qa'>('search')
+  const [query, setQuery] = useState('')
+  const [activeTab, setActiveTab] = useState<'all' | 'codex' | 'character' | 'worldRule'>('all')
+  const [selectedResult, setSelectedResult] = useState<SearchResult | null>(null)
+  const [qaMessages, setQaMessages] = useState<QAMessage[]>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      return saved ? JSON.parse(saved) : []
+    } catch {
+      return []
+    }
+  })
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [showExtractModal, setShowExtractModal] = useState(false)
+  const [isExtracting, setIsExtracting] = useState(false)
+  const [extractedSettings, setExtractedSettings] = useState<ExtractedSetting[]>([])
+  const [selectedSettings, setSelectedSettings] = useState<Set<string>>(new Set())
+
+  const chatContainerRef = useRef<HTMLDivElement>(null)
+
+  const { categories: codexCategories, entries: codexEntries, addEntry, updateEntry } = useCodexStore()
+  const { characters } = useCharacterStore()
+  const { profile: worldRulesProfile } = useWorldRulesStore()
+
+  useEffect(() => {
+    if (chatContainerRef.current) {
+      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight
+    }
+  }, [qaMessages])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(qaMessages))
+  }, [qaMessages])
+
+  const results = useMemo<SearchResult[]>(() => {
+    if (!query.trim() || mode === 'qa') return []
+
+    const q = query.trim()
+    const allResults: SearchResult[] = []
+
+    if (activeTab === 'all' || activeTab === 'codex') {
+      for (const entry of codexEntries) {
+        const category = codexCategories.find(c => c.id === entry.categoryId)
+        const fields = parseEntryFields(entry.fields)
+        const fieldsText = Object.values(fields).join(' ')
+        const score = scoreCodexEntry(entry.name, entry.summary, fieldsText, q)
+        if (score > 0) {
+          allResults.push({
+            type: 'codex',
+            id: entry.id!,
+            name: entry.name,
+            summary: entry.summary,
+            category: category?.name,
+            icon: category?.icon,
+            score,
+            data: entry,
+          })
+        }
+      }
+    }
+
+    if (activeTab === 'all' || activeTab === 'character') {
+      for (const char of characters) {
+        const score = scoreCodexEntry(
+          char.name,
+          char.shortDescription || '',
+          `${char.role || ''} ${char.personality || ''} ${char.background || ''}`,
+          q,
+        )
+        if (score > 0) {
+          allResults.push({
+            type: 'character',
+            id: char.id!,
+            name: char.name,
+            summary: char.shortDescription || '暂无简介',
+            category: char.role || '角色',
+            icon: '👤',
+            score,
+            data: char,
+          })
+        }
+      }
+    }
+
+    if (activeTab === 'all' || activeTab === 'worldRule') {
+      const traverseTree = (nodes: WorldRuleNodeDef[], parentLabel?: string) => {
+        for (const node of nodes) {
+          const entry = worldRulesProfile?.entries[node.id]
+          const content = entry
+            ? `${entry.historicalAnchors} ${entry.fictionalAdaptations}`
+            : node.label + (node.hints?.join(' ') || '')
+          const score = scoreCodexEntry(node.label, content, '', q)
+          if (score > 0) {
+            allResults.push({
+              type: 'worldRule',
+              id: node.id,
+              name: node.label,
+              summary: entry
+                ? (entry.historicalAnchors || entry.fictionalAdaptations).slice(0, 100) +
+                  ((entry.historicalAnchors || entry.fictionalAdaptations).length > 100 ? '...' : '')
+                : '暂无设定',
+              category: parentLabel || '世界规则',
+              icon: node.icon || '📜',
+              score,
+              data: {
+                node,
+                entry: entry
+                  ? {
+                      historicalAnchors: entry.historicalAnchors,
+                      fictionalAdaptations: entry.fictionalAdaptations,
+                      priority: entry.priority,
+                    }
+                  : undefined,
+              },
+            })
+          }
+          if (node.children) {
+            traverseTree(node.children, node.label)
+          }
+        }
+      }
+      traverseTree(WORLD_RULE_TREE)
+    }
+
+    return allResults.sort((a, b) => b.score - a.score).slice(0, 20)
+  }, [query, activeTab, codexEntries, codexCategories, characters, worldRulesProfile, mode])
+
+  const buildKnowledgeContext = useCallback(() => {
+    const parts: string[] = []
+
+    if (codexEntries.length > 0) {
+      const catById = new Map(codexCategories.map(c => [c.id!, c]))
+      parts.push('【设定词条】')
+      for (const entry of codexEntries) {
+        const category = catById.get(entry.categoryId)
+        const fields = parseEntryFields(entry.fields)
+        const fieldDefs = parseFieldSchema(category?.fieldSchema || '')
+        const fieldLines = fieldDefs
+          .map(d => {
+            const v = fields[d.key]
+            return v ? `${d.label}: ${v}` : ''
+          })
+          .filter(Boolean)
+        parts.push(`- ${entry.name}${entry.summary ? `（${entry.summary}）` : ''}`)
+        if (fieldLines.length > 0) {
+          parts.push('  ' + fieldLines.join('；'))
+        }
+      }
+    }
+
+    if (characters.length > 0) {
+      parts.push('\n【角色信息】')
+      for (const char of characters) {
+        parts.push(`- ${char.name}${char.identity ? `（${char.identity}）` : ''}`)
+        if (char.shortDescription) parts.push(`  简介：${char.shortDescription}`)
+        if (char.personality) parts.push(`  性格：${char.personality}`)
+        if (char.background) parts.push(`  背景：${char.background}`)
+      }
+    }
+
+    if (worldRulesProfile) {
+      parts.push('\n【世界规则】')
+      const traverseRules = (nodes: WorldRuleNodeDef[], prefix: string = '') => {
+        for (const node of nodes) {
+          const entry = worldRulesProfile.entries[node.id]
+          if (entry) {
+            const content = [
+              entry.historicalAnchors ? `📜 ${entry.historicalAnchors}` : '',
+              entry.fictionalAdaptations ? `✨ ${entry.fictionalAdaptations}` : '',
+            ].filter(Boolean).join('\n')
+            parts.push(`${prefix}- ${node.label}`)
+            if (content) parts.push(prefix + '  ' + content)
+          }
+          if (node.children) {
+            traverseRules(node.children, prefix + '  ')
+          }
+        }
+      }
+      traverseRules(WORLD_RULE_TREE)
+    }
+
+    return parts.join('\n')
+  }, [codexEntries, codexCategories, characters, worldRulesProfile])
+
+  const handleQASubmit = useCallback(async () => {
+    if (!query.trim() || isGenerating) return
+
+    const userQuestion = query.trim()
+    setIsGenerating(true)
+    setQuery('')
+
+    setQaMessages(prev => [...prev, { role: 'user', content: userQuestion }])
+
+    const knowledgeContext = buildKnowledgeContext()
+    const systemPrompt = `你是一位设定专家，专门协助作者讨论和完善小说设定。
+
+当前设定信息：
+${knowledgeContext}
+
+对话规则：
+1. 用户可能会询问现有设定，也可能提出新的设定想法进行讨论
+2. 如果设定中没有相关信息，明确说明"设定中未提及"，并可以提出建议
+3. 当用户提出新设定想法时，积极参与讨论，帮助完善细节
+4. 回答要简洁明了，直接给出答案或建议
+5. 如果需要推断，请说明推断依据`
+
+    try {
+      const messages = [
+        { role: 'system' as const, content: systemPrompt },
+        ...qaMessages.map(m => ({ role: m.role as 'system' | 'user' | 'assistant', content: m.content })),
+        { role: 'user' as const, content: userQuestion },
+      ]
+
+      setQaMessages(prev => [...prev, { role: 'assistant', content: '' }])
+
+      for await (const chunk of streamChat(messages, aiConfig, undefined, undefined, { category: 'setting-qa', projectId })) {
+        setQaMessages(prev => {
+          const last = [...prev]
+          last[last.length - 1] = { role: 'assistant', content: last[last.length - 1].content + chunk }
+          return last
+        })
+      }
+    } catch (error) {
+      console.error('QA error:', error)
+      setQaMessages(prev => [...prev, { role: 'assistant', content: '抱歉，AI 回答失败，请重试' }])
+    } finally {
+      setIsGenerating(false)
+    }
+  }, [query, isGenerating, buildKnowledgeContext, aiConfig, projectId, qaMessages])
+
+  const handleExtractSettings = useCallback(async () => {
+    if (qaMessages.length === 0 || isExtracting) return
+
+    setIsExtracting(true)
+    setShowExtractModal(true)
+    setExtractedSettings([])
+
+    const conversationText = qaMessages.map(m => `${m.role === 'user' ? '用户' : 'AI'}：${m.content}`).join('\n\n')
+    const knowledgeContext = buildKnowledgeContext()
+
+    const extractPrompt = `你是一位设定提取专家。请分析以下对话内容，提取其中讨论的新设定或对现有设定的修改。
+
+当前已有设定：
+${knowledgeContext}
+
+对话历史：
+${conversationText}
+
+请从对话中提取出需要添加或修改的设定条目。每个条目应该是一个独立的实体（地点、物品、角色、势力等）。
+
+输出格式要求：
+请输出 JSON 数组，每个元素包含以下字段：
+- name: 词条名称
+- category: 分类名称（如：城池重镇、人工器物、种族民族等）
+- categoryKey: 分类的内置键（如：city、artifact、race、faction、mineral、herb、beast 等）
+- summary: 一句话简介
+- fields: 对象，包含该词条的字段及其值
+
+如果对话中没有讨论任何新设定或修改，请返回空数组。
+
+注意：
+1. 只提取对话中明确讨论的内容，不要凭空猜测
+2. 如果是对现有词条的修改，请确保 name 与现有词条完全匹配
+3. categoryKey 必须是以下之一：city, artifact, race, faction, mineral, herb, beast, natStructure, natDimension, natTerrain, natWater, natClimate, humEra, humEvent, humSociety, humConflict, originPower, originDeity`
+
+    try {
+      const response = await chat(
+        [
+          { role: 'system', content: extractPrompt },
+        ],
+        aiConfig,
+        { category: 'setting-extract', projectId },
+      )
+
+      const jsonMatch = response.match(/\[.*\]/s)
+      if (jsonMatch) {
+        const extracted = JSON.parse(jsonMatch[0]) as ExtractedSetting[]
+        setExtractedSettings(extracted.map((s, idx) => ({ ...s, id: `${idx}` })))
+        setSelectedSettings(new Set(extracted.map((_, idx) => `${idx}`)))
+      } else {
+        setExtractedSettings([])
+      }
+    } catch (error) {
+      console.error('Extract error:', error)
+      setExtractedSettings([])
+    } finally {
+      setIsExtracting(false)
+    }
+  }, [qaMessages, isExtracting, buildKnowledgeContext, aiConfig, projectId])
+
+  const handleSaveSettings = useCallback(async () => {
+    const toSave = extractedSettings.filter(s => selectedSettings.has(s.id))
+    
+    for (const setting of toSave) {
+      const category = codexCategories.find(c => c.builtInKey === setting.categoryKey)
+      if (!category) continue
+
+      const existingEntry = codexEntries.find(e => e.categoryId === category.id && e.name === setting.name)
+
+      if (existingEntry) {
+        const fields = parseEntryFields(existingEntry.fields)
+        Object.assign(fields, setting.fields)
+        await updateEntry(existingEntry.id!, {
+          fields: JSON.stringify(fields),
+          summary: setting.summary || existingEntry.summary,
+        })
+      } else {
+        await addEntry({
+          projectId,
+          categoryId: category.id!,
+          name: setting.name,
+          summary: setting.summary,
+          description: '',
+          fields: JSON.stringify(setting.fields),
+          order: codexEntries.filter(e => e.categoryId === category.id!).length,
+        })
+      }
+    }
+
+    setShowExtractModal(false)
+    setExtractedSettings([])
+    setSelectedSettings(new Set())
+
+    setQaMessages(prev => [...prev, { role: 'assistant', content: `✅ 已将 ${toSave.length} 条设定加入系统。您可以继续提问或清空对话。` }])
+  }, [extractedSettings, selectedSettings, codexCategories, codexEntries, projectId, addEntry, updateEntry])
+
+  const renderDetail = () => {
+    if (!selectedResult) return null
+
+    if (selectedResult.type === 'codex') {
+      const entry = selectedResult.data as CodexEntry
+      const category = codexCategories.find(c => c.id === entry.categoryId)
+      const fields = parseEntryFields(entry.fields)
+      const fieldDefs = parseFieldSchema(category?.fieldSchema || '')
+
+      return (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <span className="text-2xl">{category?.icon}</span>
+            <div>
+              <h3 className="font-semibold text-text-primary">{entry.name}</h3>
+              <span className="text-xs text-text-muted">{category?.name}</span>
+            </div>
+          </div>
+          {entry.summary && (
+            <p className="text-sm text-text-secondary">{entry.summary}</p>
+          )}
+          {entry.description && (
+            <div className="p-3 bg-bg-base rounded-lg text-sm text-text-secondary whitespace-pre-wrap">
+              {entry.description}
+            </div>
+          )}
+          {Object.keys(fields).length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-text-muted">详细信息</p>
+              {fieldDefs.map(def => {
+                const value = fields[def.key]
+                if (!value) return null
+                return (
+                  <div key={def.key} className="flex items-start gap-2">
+                    <span className="text-xs text-text-muted w-20 shrink-0">{def.label}</span>
+                    <span className="text-xs text-text-secondary break-all">{value}</span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    if (selectedResult.type === 'character') {
+      const char = selectedResult.data as Character
+      return (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <span className="text-2xl">👤</span>
+            <div>
+              <h3 className="font-semibold text-text-primary">{char.name}</h3>
+              {char.identity && <span className="text-xs text-text-muted">身份：{char.identity}</span>}
+            </div>
+          </div>
+          {char.shortDescription && (
+            <p className="text-sm text-text-secondary">{char.shortDescription}</p>
+          )}
+          {char.personality && (
+            <div className="p-3 bg-bg-base rounded-lg">
+              <p className="text-xs text-text-muted mb-1">性格</p>
+              <p className="text-sm text-text-secondary">{char.personality}</p>
+            </div>
+          )}
+          {char.background && (
+            <div className="p-3 bg-bg-base rounded-lg">
+              <p className="text-xs text-text-muted mb-1">背景</p>
+              <p className="text-sm text-text-secondary whitespace-pre-wrap">{char.background}</p>
+            </div>
+          )}
+          {char.abilities && (
+            <div className="p-3 bg-bg-base rounded-lg">
+              <p className="text-xs text-text-muted mb-1">能力</p>
+              <p className="text-sm text-text-secondary whitespace-pre-wrap">{char.abilities}</p>
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    if (selectedResult.type === 'worldRule') {
+      const data = selectedResult.data as { node: WorldRuleNodeDef; entry?: { historicalAnchors: string; fictionalAdaptations: string; priority: string } }
+      return (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <span className="text-2xl">{data.node.icon || '📜'}</span>
+            <div>
+              <h3 className="font-semibold text-text-primary">{data.node.label}</h3>
+              <span className="text-xs text-text-muted">{selectedResult.category}</span>
+            </div>
+          </div>
+          {data.node.hints && data.node.hints.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {data.node.hints.map((hint, idx) => (
+                <span key={idx} className="px-2 py-0.5 text-[10px] bg-bg-base rounded text-text-muted">
+                  {hint}
+                </span>
+              ))}
+            </div>
+          )}
+          {data.entry && (
+            <>
+              {data.entry.historicalAnchors && (
+                <div className="p-3 bg-bg-base rounded-lg">
+                  <p className="text-xs text-text-muted mb-1">📜 取自真实</p>
+                  <p className="text-sm text-text-secondary whitespace-pre-wrap">{data.entry.historicalAnchors}</p>
+                </div>
+              )}
+              {data.entry.fictionalAdaptations && (
+                <div className="p-3 bg-bg-base rounded-lg">
+                  <p className="text-xs text-text-muted mb-1">✨ 架空改造</p>
+                  <p className="text-sm text-text-secondary whitespace-pre-wrap">{data.entry.fictionalAdaptations}</p>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-text-muted">⚖️ 冲突时优先：</span>
+                <span className={`text-xs px-2 py-0.5 rounded ${
+                  data.entry.priority === 'historical' ? 'bg-blue-500/10 text-blue-400' :
+                  data.entry.priority === 'fictional' ? 'bg-purple-500/10 text-purple-400' :
+                  'bg-gray-500/10 text-gray-400'
+                }`}>
+                  {data.entry.priority === 'historical' ? '史实优先' :
+                   data.entry.priority === 'fictional' ? '架空优先' : '均衡'}
+                </span>
+              </div>
+            </>
+          )}
+          {!data.entry && (
+            <p className="text-xs text-text-muted">暂无设定</p>
+          )}
+        </div>
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-2xl mx-4 bg-bg-elevated border border-border rounded-xl shadow-xl overflow-hidden">
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-2">
+            <Search className="w-4 h-4 text-accent" />
+            <h2 className="text-sm font-medium text-text-primary">设定查询</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-bg-hover rounded transition-colors"
+          >
+            <X className="w-4 h-4 text-text-muted" />
+          </button>
+        </div>
+
+        <div className="p-4 border-b border-border">
+          <div className="flex gap-1 mb-3">
+            <button
+              onClick={() => setMode('search')}
+              className={`flex items-center gap-1 px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                mode === 'search'
+                  ? 'bg-accent text-white'
+                  : 'bg-bg-base text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              <Search className="w-3 h-3" />
+              硬查询
+            </button>
+            <button
+              onClick={() => {
+                setMode('qa')
+                setSelectedResult(null)
+              }}
+              className={`flex items-center gap-1 px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                mode === 'qa'
+                  ? 'bg-accent text-white'
+                  : 'bg-bg-base text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              <Sparkles className="w-3 h-3" />
+              AI 问答
+            </button>
+          </div>
+
+          {mode === 'search' && (
+            <>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={e => setQuery(e.target.value)}
+                  placeholder="搜索武功招式、角色、地点、物品、规则..."
+                  className="w-full pl-9 pr-4 py-2 bg-bg-base border border-border rounded-lg text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent"
+                />
+              </div>
+
+              <div className="flex gap-1 mt-3">
+                {[
+                  { key: 'all', label: '全部', icon: Hash },
+                  { key: 'codex', label: '词条', icon: BookOpen },
+                  { key: 'character', label: '角色', icon: Users },
+                  { key: 'worldRule', label: '规则', icon: Scroll },
+                ].map(tab => (
+                  <button
+                    key={tab.key}
+                    onClick={() => {
+                      setActiveTab(tab.key as typeof activeTab)
+                      setSelectedResult(null)
+                    }}
+                    className={`flex items-center gap-1 px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                      activeTab === tab.key
+                        ? 'bg-accent text-white'
+                        : 'bg-bg-base text-text-muted hover:text-text-secondary'
+                    }`}
+                  >
+                    <tab.icon className="w-3 h-3" />
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {mode === 'qa' && (
+            <p className="text-[10px] text-text-muted">
+              💡 AI 问答支持多轮对话讨论设定。讨论确定后，点击下方按钮一键整理并加入设定。对话历史会自动保存，关闭后重新打开仍可见。
+            </p>
+          )}
+
+          </div>
+
+        {mode === 'search' ? (
+          <div className="flex h-80">
+            <div className="w-1/2 border-r border-border overflow-y-auto">
+              {results.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-full text-text-muted">
+                  <Search className="w-8 h-8 mb-2 opacity-30" />
+                  <p className="text-xs">输入关键词搜索设定</p>
+                </div>
+              ) : (
+                <div className="p-2 space-y-1">
+                  {results.map(result => (
+                    <button
+                      key={`${result.type}-${result.id}`}
+                      onClick={() => setSelectedResult(result)}
+                      className={`w-full text-left p-2 rounded-lg transition-colors ${
+                        selectedResult?.id === result.id && selectedResult?.type === result.type
+                          ? 'bg-accent/10'
+                          : 'hover:bg-bg-hover'
+                      }`}
+                    >
+                      <div className="flex items-start gap-2">
+                        <span className="text-lg">{result.icon}</span>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm text-text-primary truncate">{result.name}</p>
+                          {result.category && (
+                            <p className="text-[10px] text-text-muted">{result.category}</p>
+                          )}
+                          <p className="text-xs text-text-secondary truncate mt-0.5">
+                            {result.summary}
+                          </p>
+                        </div>
+                        <span className="text-[10px] text-text-muted/50">
+                          {result.type === 'codex' ? '词条' : result.type === 'character' ? '角色' : '规则'}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="w-1/2 overflow-y-auto p-4">
+              {selectedResult ? (
+                renderDetail()
+              ) : (
+                <div className="flex flex-col items-center justify-center h-full text-text-muted">
+                  <BookOpen className="w-8 h-8 mb-2 opacity-30" />
+                  <p className="text-xs">选择一个结果查看详情</p>
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col h-96">
+            <div ref={chatContainerRef} className="flex-1 overflow-y-auto p-4 space-y-3">
+              {qaMessages.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-full text-text-muted">
+                  <Sparkles className="w-8 h-8 mb-2 opacity-30" />
+                  <p className="text-xs">输入问题让 AI 分析设定</p>
+                  <p className="text-[10px] mt-1">支持多轮对话讨论设定，讨论确定后一键加入</p>
+                </div>
+              ) : (
+                qaMessages.map((msg, idx) => (
+                  <div
+                    key={idx}
+                    className={`flex gap-3 ${msg.role === 'user' ? 'flex-row-reverse' : ''}`}
+                  >
+                    <div className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs ${
+                      msg.role === 'user' ? 'bg-accent text-white' : 'bg-bg-base text-text-muted'
+                    }`}>
+                      {msg.role === 'user' ? '👤' : '🤖'}
+                    </div>
+                    <div className={`max-w-[70%] ${
+                      msg.role === 'user' ? 'items-end' : 'items-start'
+                    }`}>
+                      <div className={`p-3 rounded-lg ${
+                        msg.role === 'user' ? 'bg-accent text-white rounded-tr-none' : 'bg-bg-base text-text-secondary rounded-tl-none'
+                      }`}>
+                        <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+              {isGenerating && (
+                <div className="flex gap-3">
+                  <div className="flex-shrink-0 w-6 h-6 rounded-full bg-bg-base flex items-center justify-center text-xs text-text-muted">
+                    🤖
+                  </div>
+                  <div className="p-3 bg-bg-base rounded-lg rounded-tl-none">
+                    <div className="flex items-center gap-1">
+                      <Loader2 className="w-4 h-4 animate-spin text-accent" />
+                      <span className="text-xs text-text-muted">AI 正在分析设定...</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="p-4 border-t border-border space-y-3">
+              <textarea
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    handleQASubmit()
+                  }
+                }}
+                placeholder="输入问题..."
+                rows={3}
+                className="w-full px-4 py-2 bg-bg-base border border-border rounded-lg text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent resize-none"
+                disabled={isGenerating}
+              />
+
+              <div className="flex gap-2">
+                <button
+                  onClick={handleExtractSettings}
+                  disabled={isExtracting || qaMessages.length === 0}
+                  className="flex-1 py-1.5 text-xs bg-accent text-white rounded-lg hover:bg-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1"
+                >
+                  <FileText className="w-3 h-3" />
+                  {isExtracting ? '提取中...' : '整理并加入设定'}
+                </button>
+                <button
+                  onClick={handleQASubmit}
+                  disabled={isGenerating || !query.trim()}
+                  className="px-4 py-1.5 text-xs bg-accent text-white rounded-lg hover:bg-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+                >
+                  {isGenerating ? <Loader2 className="w-3 h-3 animate-spin" /> : <Send className="w-3 h-3" />}
+                  {isGenerating ? '思考中' : '发送'}
+                </button>
+                <button
+                  onClick={() => {
+                    setQaMessages([])
+                    localStorage.removeItem(STORAGE_KEY)
+                  }}
+                  className="px-4 py-1.5 text-xs text-text-muted hover:text-text-secondary transition-colors"
+                >
+                  清空
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {showExtractModal && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/50">
+            <div className="w-full max-w-lg mx-4 bg-bg-elevated border border-border rounded-xl shadow-xl overflow-hidden max-h-[80vh] flex flex-col">
+              <div className="flex items-center justify-between p-4 border-b border-border">
+                <h3 className="text-sm font-medium text-text-primary">整理设定</h3>
+                <button
+                  onClick={() => {
+                    setShowExtractModal(false)
+                    setExtractedSettings([])
+                    setSelectedSettings(new Set())
+                  }}
+                  className="p-1 hover:bg-bg-hover rounded transition-colors"
+                >
+                  <X className="w-4 h-4 text-text-muted" />
+                </button>
+              </div>
+
+              <div className="flex-1 overflow-y-auto p-4">
+                {isExtracting ? (
+                  <div className="flex flex-col items-center justify-center h-full text-text-muted">
+                    <Loader2 className="w-8 h-8 animate-spin mb-2 opacity-50" />
+                    <p className="text-xs">AI 正在分析对话提取设定...</p>
+                  </div>
+                ) : extractedSettings.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center h-full text-text-muted">
+                    <FileText className="w-8 h-8 mb-2 opacity-30" />
+                    <p className="text-xs">对话中未发现需要添加的设定</p>
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {extractedSettings.map(setting => (
+                      <div
+                        key={setting.id}
+                        className={`p-3 rounded-lg border transition-colors ${
+                          selectedSettings.has(setting.id)
+                            ? 'border-accent bg-accent/5'
+                            : 'border-border bg-bg-base'
+                        }`}
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                              <input
+                                type="checkbox"
+                                checked={selectedSettings.has(setting.id)}
+                                onChange={(e) => {
+                                  const next = new Set(selectedSettings)
+                                  if (e.target.checked) {
+                                    next.add(setting.id)
+                                  } else {
+                                    next.delete(setting.id)
+                                  }
+                                  setSelectedSettings(next)
+                                }}
+                                className="w-3 h-3 rounded border-border text-accent focus:ring-accent"
+                              />
+                              <span className="text-sm font-medium text-text-primary">{setting.name}</span>
+                              <span className="text-[10px] text-text-muted px-1.5 py-0.5 bg-bg-hover rounded">
+                                {setting.category}
+                              </span>
+                            </div>
+                            {setting.summary && (
+                              <p className="text-xs text-text-secondary mb-2">{setting.summary}</p>
+                            )}
+                            {Object.keys(setting.fields).length > 0 && (
+                              <div className="space-y-1">
+                                {Object.entries(setting.fields).map(([key, value]) => (
+                                  <div key={key} className="flex items-start gap-2">
+                                    <span className="text-xs text-text-muted w-16 shrink-0">{key}</span>
+                                    <span className="text-xs text-text-secondary">{value}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {!isExtracting && extractedSettings.length > 0 && (
+                <div className="flex gap-2 p-4 border-t border-border">
+                  <button
+                    onClick={() => {
+                      setShowExtractModal(false)
+                      setExtractedSettings([])
+                      setSelectedSettings(new Set())
+                    }}
+                    className="flex-1 px-4 py-2 text-xs bg-bg-base text-text-secondary rounded-lg hover:bg-bg-hover transition-colors"
+                  >
+                    取消
+                  </button>
+                  <button
+                    onClick={handleSaveSettings}
+                    disabled={selectedSettings.size === 0}
+                    className="flex-1 px-4 py-2 text-xs bg-accent text-white rounded-lg hover:bg-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1"
+                  >
+                    <Check className="w-3 h-3" />
+                    保存 {selectedSettings.size} 条设定
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/sidebar-tree.ts
+++ b/src/components/layout/sidebar-tree.ts
@@ -6,6 +6,7 @@ import {
   FileCog, History, Upload, Download, Settings,
   Map, ClipboardList, GitBranch, Clock, MapPin, Scale,
   Drama, Package, CalendarClock, ScanSearch, Coins, Feather, Database,
+  Replace,
 } from 'lucide-react'
 
 /**
@@ -45,6 +46,7 @@ export type SidebarModule =
   | 'editor'
   | 'foreshadow'
   | 'style-learning'        // FB-5 自适应文风学习
+  | 'global-replace'        // 全局替换
 
   // 作品学习（一级）
   | 'master-studies'
@@ -145,6 +147,7 @@ export const MODULE_CONTENT_TYPES: Record<SidebarModule, ModuleContentType> = {
   editor: 'writing',
   foreshadow: 'upstream',
   'style-learning': 'tool',
+  'global-replace': 'tool',
   'master-studies': 'tool',
   prompts: 'system',
   'version-history': 'system',
@@ -263,6 +266,7 @@ export const NAV_TREE: TreeSection[] = [
       leaf('chapters-list',    '章节',     FilePen),
       leaf('foreshadow',       '伏笔',     Eye),
       leaf('style-learning',   '文风学习', Feather),
+      leaf('global-replace',   '全局替换', Replace),
       leaf('locations',        '重要地点', MapPin),
       leaf('state-table',      '状态表',   ClipboardList),
       leaf('inventory',        '物品栏',   Package),

--- a/src/components/outline/ChunkOptionDialog.tsx
+++ b/src/components/outline/ChunkOptionDialog.tsx
@@ -1,0 +1,109 @@
+import type { ChunkConfig, ChunkOption } from '../../lib/ai/chunked-chapter-generator'
+
+interface Props {
+  chunk: ChunkConfig
+  options: ChunkOption[]
+  onSelect: (option: ChunkOption) => void
+  onCancel: () => void
+}
+
+export default function ChunkOptionDialog({ chunk, options, onSelect, onCancel }: Props) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[10000] p-4">
+      <div className="bg-bg-base rounded-xl shadow-2xl max-w-3xl w-full max-h-[80vh] overflow-hidden border border-border">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <div>
+            <h2 className="text-lg font-semibold text-text-primary">
+              选择剧情走向 — {chunk.title}
+            </h2>
+            <p className="text-sm text-text-muted mt-1">
+              本块章节范围：第{chunk.startChapter}-{chunk.endChapter}章 · 情绪基调：{chunk.emotionalTone} · 节奏：{chunk.pace}
+            </p>
+          </div>
+          <button
+            onClick={onCancel}
+            className="p-2 hover:bg-bg-hover rounded-lg transition-colors"
+          >
+            <svg className="w-5 h-5 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto max-h-[calc(80vh-120px)]">
+          <div className="grid gap-4">
+            {options.map((option, index) => (
+              <div
+                key={option.id}
+                onClick={() => onSelect(option)}
+                className="border border-border rounded-lg p-4 cursor-pointer hover:border-accent hover:bg-accent/5 transition-all group"
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-3">
+                    <span className="w-8 h-8 rounded-full bg-accent/10 text-accent flex items-center justify-center font-medium text-sm">
+                      {index + 1}
+                    </span>
+                    <span className="font-medium text-text-primary">{option.description}</span>
+                  </div>
+                  <div className={`px-2 py-1 rounded text-xs font-medium ${
+                    option.deviation.score <= 30 ? 'bg-success/10 text-success' :
+                    option.deviation.score <= 60 ? 'bg-warning/10 text-warning' :
+                    'bg-error/10 text-error'
+                  }`}>
+                    偏离度 {option.deviation.score}%
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-start gap-2">
+                    <span className="w-5 h-5 rounded bg-accent/10 text-accent text-xs flex items-center justify-center flex-shrink-0 mt-0.5">起</span>
+                    <p className="text-sm text-text-secondary whitespace-pre-wrap">
+                      {option.chapters[0]?.summary || '暂无描述'}
+                    </p>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <span className="w-5 h-5 rounded bg-accent/10 text-accent text-xs flex items-center justify-center flex-shrink-0 mt-0.5">承</span>
+                    <p className="text-sm text-text-secondary whitespace-pre-wrap">
+                      {option.chapters[Math.floor(option.chapters.length / 2)]?.summary || '暂无描述'}
+                    </p>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <span className="w-5 h-5 rounded bg-accent/10 text-accent text-xs flex items-center justify-center flex-shrink-0 mt-0.5">转</span>
+                    <p className="text-sm text-text-secondary whitespace-pre-wrap">
+                      {option.chapters[option.chapters.length - 1]?.summary || '暂无描述'}
+                    </p>
+                  </div>
+                  <div className="text-xs text-text-muted">
+                    共 {option.chapters.length} 章
+                  </div>
+                </div>
+
+                {option.deviation.warnings.length > 0 && (
+                  <div className="mt-3 pt-3 border-t border-border">
+                    <div className="text-xs text-warning">
+                      <span className="font-medium">⚠️ 检测到偏离：</span>
+                      {option.deviation.warnings.slice(0, 2).join('；')}
+                      {option.deviation.warnings.length > 2 && `等 ${option.deviation.warnings.length} 项`}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between px-6 py-4 border-t border-border bg-bg-elevated">
+          <p className="text-sm text-text-muted">
+            选择后将继续生成下一块章节
+          </p>
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-sm text-text-secondary border border-border rounded-lg hover:bg-bg-hover transition-colors"
+          >
+            取消
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/outline/ChunkPreviewPanel.tsx
+++ b/src/components/outline/ChunkPreviewPanel.tsx
@@ -1,0 +1,118 @@
+import type { ChunkConfig, DeviationAnalysis } from '../../lib/ai/chunked-chapter-generator'
+import type { ParsedChapter } from '../../lib/ai/parse-outline-output'
+
+interface ChunkPreviewItem {
+  chunk: ChunkConfig
+  chapters: ParsedChapter[]
+  deviation?: DeviationAnalysis
+}
+
+interface Props {
+  chunks: ChunkPreviewItem[]
+  onRegenerateChunk?: (index: number) => void
+  onAutoAdjustChunk?: (index: number) => void
+}
+
+const TONE_COLORS: Record<string, string> = {
+  '平静': 'bg-blue-500',
+  '紧张': 'bg-orange-500',
+  '高潮': 'bg-red-500',
+  '低落': 'bg-gray-500',
+  '转折': 'bg-purple-500',
+}
+
+const PACE_LABELS: Record<string, string> = {
+  '慢': '慢',
+  '中': '中',
+  '快': '快',
+  '极快': '极快',
+}
+
+export default function ChunkPreviewPanel({ chunks, onRegenerateChunk, onAutoAdjustChunk }: Props) {
+  return (
+    <div className="space-y-3">
+      <div className="text-xs font-medium text-text-primary">分块预览</div>
+      
+      {chunks.map((item, idx) => {
+        const hasDeviation = item.deviation && item.deviation.score > 30
+        const isSevere = item.deviation && item.deviation.score > 60
+        
+        return (
+          <div
+            key={idx}
+            className={`rounded-lg border p-3 ${
+              isSevere ? 'border-error bg-error/5' :
+              hasDeviation ? 'border-warning bg-warning/5' :
+              'border-border bg-bg-elevated'
+            }`}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium text-text-primary">{item.chunk.title}</span>
+                <span className={`px-1.5 py-0.5 rounded text-[10px] text-white ${TONE_COLORS[item.chunk.emotionalTone] || 'bg-gray-500'}`}>
+                  {item.chunk.emotionalTone}
+                </span>
+                <span className="text-[10px] text-text-muted">
+                  {PACE_LABELS[item.chunk.pace]}节奏
+                </span>
+              </div>
+              
+              {hasDeviation && (
+                <div className="flex items-center gap-2">
+                  <span className={`text-[10px] ${isSevere ? 'text-error' : 'text-warning'}`}>
+                    偏离度 {item.deviation!.score}%
+                  </span>
+                  {isSevere && onAutoAdjustChunk && (
+                    <button
+                      onClick={() => onAutoAdjustChunk(idx)}
+                      className="px-2 py-0.5 text-[10px] bg-accent text-white rounded hover:bg-accent/80"
+                    >
+                      自动调整
+                    </button>
+                  )}
+                  {onRegenerateChunk && (
+                    <button
+                      onClick={() => onRegenerateChunk(idx)}
+                      className="px-2 py-0.5 text-[10px] border border-border rounded hover:bg-bg-hover"
+                    >
+                      重新生成
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+            
+            {hasDeviation && item.deviation && (
+              <div className="mb-2 text-[10px] text-text-muted space-y-1">
+                {item.deviation.warnings.slice(0, 3).map((warning, i) => (
+                  <div key={i} className="flex items-start gap-1">
+                    <span className="text-error">●</span>
+                    <span>{warning}</span>
+                  </div>
+                ))}
+                {item.deviation.suggestions.length > 0 && (
+                  <div className="flex items-start gap-1">
+                    <span className="text-accent">○</span>
+                    <span>建议：{item.deviation.suggestions[0]}</span>
+                  </div>
+                )}
+              </div>
+            )}
+            
+            <div className="space-y-1">
+              {item.chapters.map((ch, chIdx) => (
+                <div
+                  key={chIdx}
+                  className="text-xs text-text-secondary truncate"
+                  title={ch.summary}
+                >
+                  {item.chunk.startChapter + chIdx}. {ch.title}：{ch.summary}
+                </div>
+              ))}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/outline/GenerationProgressPanel.tsx
+++ b/src/components/outline/GenerationProgressPanel.tsx
@@ -1,0 +1,64 @@
+interface Props {
+  visible: boolean
+  stage: string
+  current: number
+  total: number
+  chunks?: { title: string; status: 'pending' | 'generating' | 'completed' | 'error' }[]
+}
+
+export default function GenerationProgressPanel({ visible, stage, current, total, chunks }: Props) {
+  if (!visible) return null
+
+  return (
+    <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[10000]">
+      <div className="bg-bg-base border border-border rounded-xl shadow-xl px-6 py-4 flex items-center gap-4 min-w-[350px]">
+        <div className="relative">
+          <div className="w-10 h-10 rounded-full bg-accent/10 flex items-center justify-center">
+            <svg className="w-5 h-5 text-accent animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+          </div>
+        </div>
+        
+        <div className="flex-1">
+          <div className="text-sm font-medium text-text-primary">{stage}</div>
+          <div className="text-xs text-text-muted mt-1">第 {current}/{total} 块</div>
+          <div className="mt-2 h-1.5 bg-bg-hover rounded-full overflow-hidden">
+            <div
+              className="h-full bg-accent rounded-full transition-all duration-300"
+              style={{ width: `${(current / total) * 100}%` }}
+            />
+          </div>
+        </div>
+
+        {chunks && chunks.length > 0 && (
+          <div className="flex flex-col gap-1 ml-4">
+            {chunks.slice(0, 5).map((chunk, idx) => (
+              <div key={idx} className="flex items-center gap-2">
+                <div className={`w-2 h-2 rounded-full ${
+                  chunk.status === 'completed' ? 'bg-success' :
+                  chunk.status === 'generating' ? 'bg-accent animate-pulse' :
+                  chunk.status === 'error' ? 'bg-error' :
+                  'bg-bg-hover'
+                }`} />
+                <span className="text-xs text-text-muted">{chunk.title}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/tools/GlobalReplacePanel.tsx
+++ b/src/components/tools/GlobalReplacePanel.tsx
@@ -1,0 +1,367 @@
+import { useState, useMemo, useCallback } from 'react'
+import { Search, Replace, BookOpen, Users, Scroll, Hash, Loader2, Check } from 'lucide-react'
+import { useCodexStore } from '../../stores/codex'
+import { useCharacterStore } from '../../stores/character'
+import { useWorldRulesStore } from '../../stores/world-rules'
+import { useChapterStore } from '../../stores/chapter'
+import { parseEntryFields } from '../../lib/types/codex'
+import { WORLD_RULE_TREE } from '../../lib/types/world-rules'
+import { useToast } from '../shared/Toast'
+import { useDialog } from '../shared/Dialog'
+import type { Project } from '../../lib/types'
+
+interface Props {
+  project: Project
+}
+
+interface ReplaceMatch {
+  type: 'codex' | 'character' | 'worldRule' | 'chapter'
+  id: number | string
+  name: string
+  field?: string
+  snippet: string
+  category?: string
+}
+
+type SearchScope = 'all' | 'codex' | 'character' | 'worldRule' | 'chapter'
+
+export default function GlobalReplacePanel({ project }: Props) {
+  const toast = useToast()
+  const dialog = useDialog()
+  const { entries: codexEntries, updateEntry } = useCodexStore()
+  const { characters, updateCharacter } = useCharacterStore()
+  const { profile: worldRulesProfile } = useWorldRulesStore()
+  const { chapters, updateChapter } = useChapterStore()
+
+  const [query, setQuery] = useState('')
+  const [replacement, setReplacement] = useState('')
+  const [scope, setScope] = useState<SearchScope>('all')
+  const [isReplacing, setIsReplacing] = useState(false)
+
+  const findReplaceMatches = useMemo(() => {
+    if (!query.trim()) return []
+
+    const q = query.trim().toLowerCase()
+    const matches: ReplaceMatch[] = []
+
+    const addMatch = (type: ReplaceMatch['type'], id: number | string, name: string, field: string, text: string, category?: string) => {
+      const idx = text.toLowerCase().indexOf(q)
+      if (idx >= 0) {
+        const start = Math.max(0, idx - 20)
+        const end = Math.min(text.length, idx + q.length + 20)
+        const snippet = `${start > 0 ? '…' : ''}${text.slice(start, end)}${end < text.length ? '…' : ''}`
+        matches.push({ type, id, name, field, snippet, category })
+      }
+    }
+
+    if (scope === 'all' || scope === 'codex') {
+      for (const entry of codexEntries) {
+        if (entry.projectId !== project.id!) continue
+        if (entry.name.toLowerCase().includes(q)) {
+          addMatch('codex', entry.id!, entry.name, '名称', entry.name)
+        }
+        if (entry.summary && entry.summary.toLowerCase().includes(q)) {
+          addMatch('codex', entry.id!, entry.name, '摘要', entry.summary)
+        }
+        if (entry.description && entry.description.toLowerCase().includes(q)) {
+          addMatch('codex', entry.id!, entry.name, '描述', entry.description)
+        }
+        const fields = parseEntryFields(entry.fields)
+        for (const [key, value] of Object.entries(fields)) {
+          if (value && value.toLowerCase().includes(q)) {
+            addMatch('codex', entry.id!, entry.name, key, value)
+          }
+        }
+      }
+    }
+
+    if (scope === 'all' || scope === 'character') {
+      for (const char of characters) {
+        if (char.projectId !== project.id!) continue
+        if (char.name.toLowerCase().includes(q)) {
+          addMatch('character', char.id!, char.name, '名称', char.name)
+        }
+        if (char.identity && char.identity.toLowerCase().includes(q)) {
+          addMatch('character', char.id!, char.name, '身份', char.identity)
+        }
+        if (char.shortDescription && char.shortDescription.toLowerCase().includes(q)) {
+          addMatch('character', char.id!, char.name, '简介', char.shortDescription)
+        }
+        if (char.personality && char.personality.toLowerCase().includes(q)) {
+          addMatch('character', char.id!, char.name, '性格', char.personality)
+        }
+        if (char.background && char.background.toLowerCase().includes(q)) {
+          addMatch('character', char.id!, char.name, '背景', char.background)
+        }
+        if (char.abilities && char.abilities.toLowerCase().includes(q)) {
+          addMatch('character', char.id!, char.name, '能力', char.abilities)
+        }
+      }
+    }
+
+    if (scope === 'all' || scope === 'worldRule') {
+      const traverseRules = (nodes: typeof WORLD_RULE_TREE) => {
+        for (const node of nodes) {
+          const entry = worldRulesProfile?.entries[node.id]
+          if (node.label.toLowerCase().includes(q)) {
+            addMatch('worldRule', node.id, node.label, '规则名称', node.label)
+          }
+          if (entry?.historicalAnchors && entry.historicalAnchors.toLowerCase().includes(q)) {
+            addMatch('worldRule', node.id, node.label, '取自真实', entry.historicalAnchors)
+          }
+          if (entry?.fictionalAdaptations && entry.fictionalAdaptations.toLowerCase().includes(q)) {
+            addMatch('worldRule', node.id, node.label, '架空改造', entry.fictionalAdaptations)
+          }
+          if (node.children) {
+            traverseRules(node.children)
+          }
+        }
+      }
+      traverseRules(WORLD_RULE_TREE)
+    }
+
+    if (scope === 'all' || scope === 'chapter') {
+      for (const chapter of chapters) {
+        if (chapter.projectId !== project.id!) continue
+        if (chapter.title && chapter.title.toLowerCase().includes(q)) {
+          addMatch('chapter', chapter.id!, chapter.title, '标题', chapter.title)
+        }
+        if (chapter.summary && chapter.summary.toLowerCase().includes(q)) {
+          addMatch('chapter', chapter.id!, chapter.title, '摘要', chapter.summary)
+        }
+        if (chapter.content && chapter.content.toLowerCase().includes(q)) {
+          addMatch('chapter', chapter.id!, chapter.title, '正文', chapter.content)
+        }
+      }
+    }
+
+    return matches.slice(0, 100)
+  }, [query, scope, codexEntries, characters, worldRulesProfile, chapters, project.id])
+
+  const executeReplace = useCallback(async () => {
+    if (!query.trim() || !replacement || findReplaceMatches.length === 0) return
+
+    const q = query.trim()
+    const escapedQ = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const replaceRegex = new RegExp(escapedQ, 'g')
+
+    const ok = await dialog.confirm({
+      title: '确认全局替换？',
+      message: `将在设定库和章节中替换 ${findReplaceMatches.length} 处「${q}」为「${replacement}」。此操作不可撤销，请确保已备份。`,
+      confirmText: '确认替换',
+      cancelText: '取消',
+      tone: 'danger',
+    })
+    if (!ok) return
+
+    let replacedCount = 0
+    setIsReplacing(true)
+
+    try {
+      for (const match of findReplaceMatches) {
+        if (match.type === 'codex') {
+          const entry = codexEntries.find(e => e.id === match.id)
+          if (!entry) continue
+
+          const updateData: Record<string, string> = {}
+          if (match.field === '名称') {
+            updateData.name = entry.name.replace(replaceRegex, replacement)
+          } else if (match.field === '摘要') {
+            updateData.summary = entry.summary.replace(replaceRegex, replacement)
+          } else if (match.field === '描述') {
+            updateData.description = entry.description.replace(replaceRegex, replacement)
+          } else if (match.field) {
+            const fields = parseEntryFields(entry.fields)
+            fields[match.field] = (fields[match.field] || '').replace(replaceRegex, replacement)
+            updateData.fields = JSON.stringify(fields)
+          }
+
+          if (Object.keys(updateData).length > 0) {
+            await updateEntry(entry.id!, updateData)
+            replacedCount++
+          }
+        } else if (match.type === 'character') {
+          const char = characters.find(c => c.id === match.id)
+          if (!char) continue
+
+          const updateData: Record<string, string> = {}
+          if (match.field === '名称') {
+            updateData.name = char.name.replace(replaceRegex, replacement)
+          } else if (match.field === '身份') {
+            updateData.identity = (char.identity || '').replace(replaceRegex, replacement)
+          } else if (match.field === '简介') {
+            updateData.shortDescription = (char.shortDescription || '').replace(replaceRegex, replacement)
+          } else if (match.field === '性格') {
+            updateData.personality = (char.personality || '').replace(replaceRegex, replacement)
+          } else if (match.field === '背景') {
+            updateData.background = (char.background || '').replace(replaceRegex, replacement)
+          } else if (match.field === '能力') {
+            updateData.abilities = (char.abilities || '').replace(replaceRegex, replacement)
+          }
+
+          if (Object.keys(updateData).length > 0) {
+            await updateCharacter(char.id!, updateData)
+            replacedCount++
+          }
+        } else if (match.type === 'chapter') {
+          const chapter = chapters.find(c => c.id === match.id)
+          if (!chapter) continue
+
+          const updateData: Record<string, string> = {}
+          if (match.field === '标题') {
+            updateData.title = chapter.title.replace(replaceRegex, replacement)
+          } else if (match.field === '摘要' && chapter.summary) {
+            updateData.summary = chapter.summary.replace(replaceRegex, replacement)
+          } else if (match.field === '正文') {
+            updateData.content = chapter.content.replace(replaceRegex, replacement)
+          }
+
+          if (Object.keys(updateData).length > 0) {
+            await updateChapter(chapter.id!, updateData)
+            replacedCount++
+          }
+        }
+      }
+
+      toast.success(`已替换 ${replacedCount} 处`)
+      setQuery('')
+      setReplacement('')
+    } catch (error) {
+      toast.error(`替换失败：${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      setIsReplacing(false)
+    }
+  }, [query, replacement, findReplaceMatches, codexEntries, characters, chapters, updateEntry, updateCharacter, updateChapter, dialog, toast])
+
+  const scopeTabs = [
+    { key: 'all', label: '全部', icon: Hash },
+    { key: 'codex', label: '设定词条', icon: BookOpen },
+    { key: 'character', label: '角色', icon: Users },
+    { key: 'worldRule', label: '世界规则', icon: Scroll },
+    { key: 'chapter', label: '章节正文', icon: Search },
+  ]
+
+  const typeColors: Record<ReplaceMatch['type'], string> = {
+    codex: 'bg-blue-500/10 text-blue-400',
+    character: 'bg-purple-500/10 text-purple-400',
+    worldRule: 'bg-green-500/10 text-green-400',
+    chapter: 'bg-orange-500/10 text-orange-400',
+  }
+
+  const typeLabels: Record<ReplaceMatch['type'], string> = {
+    codex: '词条',
+    character: '角色',
+    worldRule: '规则',
+    chapter: '章节',
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="p-6 border-b border-border">
+        <h1 className="text-lg font-semibold text-text-primary mb-1">全局替换</h1>
+        <p className="text-xs text-text-muted">在设定库和章节中查找并替换内容。支持词条、角色、世界规则和章节正文。</p>
+      </div>
+
+      <div className="p-6">
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          <div className="col-span-2 space-y-1">
+            <label className="text-xs text-text-muted">查找</label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+              <input
+                type="text"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder="输入要查找的内容"
+                className="w-full pl-10 pr-4 py-3 bg-bg-base border border-border rounded-xl text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent"
+              />
+            </div>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-text-muted">替换为</label>
+            <div className="relative">
+              <Replace className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+              <input
+                type="text"
+                value={replacement}
+                onChange={e => setReplacement(e.target.value)}
+                placeholder="替换内容"
+                className="w-full pl-10 pr-4 py-3 bg-bg-base border border-border rounded-xl text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 mb-6">
+          {scopeTabs.map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => setScope(tab.key as SearchScope)}
+              className={`flex items-center gap-1.5 px-4 py-2 text-xs rounded-lg transition-colors ${
+                scope === tab.key
+                  ? 'bg-accent text-white'
+                  : 'bg-bg-base text-text-muted hover:text-text-secondary'
+              }`}
+            >
+              <tab.icon className="w-3 h-3" />
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-xs text-text-muted">
+            共找到 <span className="font-medium text-accent">{findReplaceMatches.length}</span> 处命中
+          </span>
+          {findReplaceMatches.length > 0 && (
+            <button
+              onClick={executeReplace}
+              disabled={isReplacing || !query.trim() || !replacement}
+              className="inline-flex items-center gap-1.5 px-4 py-2 text-xs bg-accent text-white rounded-lg hover:bg-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isReplacing ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
+              {isReplacing ? '替换中...' : '执行替换'}
+            </button>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-y-auto bg-bg-base rounded-xl border border-border">
+          {findReplaceMatches.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-64 text-text-muted">
+              <Search className="w-12 h-12 mb-3 opacity-20" />
+              <p className="text-sm">输入查找内容开始搜索</p>
+              <p className="text-xs mt-1">支持在设定词条、角色、世界规则和章节正文中搜索</p>
+            </div>
+          ) : (
+            <div className="p-4 space-y-3">
+              {findReplaceMatches.map((match, idx) => (
+                <div
+                  key={idx}
+                  className="p-4 bg-bg-elevated rounded-lg border border-border hover:border-accent/30 transition-colors"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className={`text-xs px-2 py-0.5 rounded ${typeColors[match.type]}`}>
+                      {typeLabels[match.type]}
+                    </span>
+                    <span className="text-sm font-medium text-text-primary">{match.name}</span>
+                    {match.field && (
+                      <span className="text-xs text-text-muted">· {match.field}</span>
+                    )}
+                    {match.category && (
+                      <span className="text-xs text-text-muted/60">· {match.category}</span>
+                    )}
+                  </div>
+                  <p className="text-xs text-text-secondary" dangerouslySetInnerHTML={{
+                    __html: match.snippet.replace(new RegExp(query, 'gi'), (matchText: string) => (
+                      `<span class="bg-accent/20 text-accent font-medium px-0.5 rounded">${matchText}</span>`
+                    ))
+                  }} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/ai/chunked-chapter-generator.ts
+++ b/src/lib/ai/chunked-chapter-generator.ts
@@ -1,0 +1,404 @@
+import { chat } from './client'
+import { buildChapterOutlinePrompt } from './adapters/outline-adapter'
+import { parseChapterOutlineSmart, type ParsedChapter } from './parse-outline-output'
+import { useAIConfigStore } from '../../stores/ai-config'
+import type { OutlineNode } from '../types'
+
+export interface ChunkConfig {
+  startChapter: number
+  endChapter: number
+  title: string
+  purpose: string
+  emotionalTone: '平静' | '紧张' | '高潮' | '低落' | '转折'
+  pace: '慢' | '中' | '快' | '极快'
+}
+
+export interface DeviationAnalysis {
+  score: number
+  dimensionScores: {
+    plotGoal: number
+    characterState: number
+    worldConsistency: number
+    foreshadowing: number
+    mainLine: number
+  }
+  warnings: string[]
+  suggestions: string[]
+}
+
+export interface ChunkGenerationResult {
+  chunk: ChunkConfig
+  chapters: ParsedChapter[]
+  deviation: DeviationAnalysis
+  needsSalvage: boolean
+}
+
+export interface SalvageOption {
+  type: 'auto-adjust' | 'transition-chapters' | 'regenerate' | 'ignore'
+  label: string
+  description: string
+  estimatedAdditionalChapters?: number
+}
+
+export interface ChunkOption {
+  id: string
+  chapters: ParsedChapter[]
+  description: string
+  deviation: DeviationAnalysis
+}
+
+export interface ChunkedGenerationOptions {
+  volume: OutlineNode
+  worldContext: string
+  prevVolumeSummary: string
+  characterContext?: string
+  worldRulesContext?: string
+  userHint?: string
+  targetChapterCount: number
+  onProgress?: (stage: string, current: number, total: number) => void
+  onChunkReady?: (chunk: ChunkConfig, options: ChunkOption[]) => Promise<ChunkOption>
+  signal?: AbortSignal
+}
+
+function generateChunks(targetChapterCount: number): ChunkConfig[] {
+  const chunks: ChunkConfig[] = []
+  
+  const ratios = [0.15, 0.25, 0.30, 0.20, 0.10]
+  const purposes = ['铺垫引入', '发展冲突', '高潮前酝酿', '高潮爆发', '收尾铺垫']
+  const tones: ChunkConfig['emotionalTone'][] = ['平静', '紧张', '紧张', '高潮', '转折']
+  const paces: ChunkConfig['pace'][] = ['慢', '中', '快', '极快', '慢']
+  
+  let currentChapter = 1
+  
+  for (let i = 0; i < ratios.length; i++) {
+    const chapterCount = Math.max(1, Math.round(targetChapterCount * ratios[i]))
+    const start = currentChapter
+    const end = Math.min(start + chapterCount - 1, targetChapterCount)
+    
+    chunks.push({
+      startChapter: start,
+      endChapter: end,
+      title: `第${i + 1}块：${purposes[i]}`,
+      purpose: purposes[i],
+      emotionalTone: tones[i],
+      pace: paces[i],
+    })
+    
+    currentChapter = end + 1
+    if (currentChapter > targetChapterCount) break
+  }
+  
+  return chunks
+}
+
+async function analyzeDeviation(
+  volumeSummary: string,
+  generatedChapters: ParsedChapter[],
+  worldRulesContext: string = '',
+): Promise<DeviationAnalysis> {
+  const config = useAIConfigStore.getState().config
+  
+  const messages = [
+    {
+      role: 'system' as const,
+      content: `你是一位专业的小说编辑和剧情分析师。请分析生成的章节大纲是否偏离了卷纲设定。
+
+分析维度：
+1. 剧情目标（权重40%）：章节是否达成卷纲设定的目标
+2. 角色状态（权重25%）：角色能力/关系是否符合预期
+3. 世界观一致性（权重20%）：是否违反已设定的世界规则
+4. 伏笔状态（权重10%）：伏笔是否按计划埋设/回收
+5. 主线推进（权重5%）：是否推进主线
+
+评分标准（0-100）：
+- 0-30：正常，基本符合预期
+- 31-60：轻微偏离，需要关注
+- 61-100：严重偏离，需要挽救
+
+输出格式：JSON
+{
+  "score": 偏离度总分,
+  "dimensionScores": {
+    "plotGoal": 分数,
+    "characterState": 分数,
+    "worldConsistency": 分数,
+    "foreshadowing": 分数,
+    "mainLine": 分数
+  },
+  "warnings": ["警告1", "警告2", ...],
+  "suggestions": ["建议1", "建议2", ...]
+}`,
+    },
+    {
+      role: 'user' as const,
+      content: `请分析以下生成的章节大纲是否偏离了卷纲设定：
+
+【卷纲】
+${volumeSummary}
+
+【世界规则】
+${worldRulesContext || '暂无'}
+
+【生成的章节】
+${generatedChapters.map((ch, i) => `${i + 1}. ${ch.title}：${ch.summary}`).join('\n')}`,
+    },
+  ]
+  
+  try {
+    const rawOutput = await chat(messages, config, { category: 'outline.deviation', projectId: 0 })
+    const trimmed = rawOutput.replace(/```json/g, '').replace(/```/g, '').trim()
+    const result = JSON.parse(trimmed) as DeviationAnalysis
+    return result
+  } catch {
+    return {
+      score: 0,
+      dimensionScores: { plotGoal: 0, characterState: 0, worldConsistency: 0, foreshadowing: 0, mainLine: 0 },
+      warnings: [],
+      suggestions: [],
+    }
+  }
+}
+
+export async function generateChunkedChapterOutline(
+  options: ChunkedGenerationOptions,
+): Promise<ParsedChapter[]> {
+  const {
+    volume,
+    worldContext,
+    prevVolumeSummary,
+    characterContext,
+    worldRulesContext,
+    userHint,
+    targetChapterCount,
+    onProgress,
+    onChunkReady,
+    signal,
+  } = options
+  
+  const config = useAIConfigStore.getState().config
+  const chunks = generateChunks(targetChapterCount)
+  const allChapters: ParsedChapter[] = []
+  let prevChunkEnding = prevVolumeSummary
+  
+  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+    if (signal?.aborted) {
+      return allChapters
+    }
+    
+    const chunk = chunks[chunkIndex]
+    const chaptersInChunk = chunk.endChapter - chunk.startChapter + 1
+    
+    onProgress?.(
+      `正在生成「${chunk.title}」（第${chunk.startChapter}-${chunk.endChapter}章）`,
+      chunkIndex + 1,
+      chunks.length,
+    )
+    
+    const optionsCount = onChunkReady ? 3 : 1
+    const chunkOptions: ChunkOption[] = []
+    
+    const variantDescriptions = [
+      '标准剧情走向',
+      '冲突增强版（更多悬念和转折）',
+      '情感细腻版（注重角色发展）',
+    ]
+    
+    for (let optIndex = 0; optIndex < optionsCount; optIndex++) {
+      if (signal?.aborted) {
+        return allChapters
+      }
+      
+      onProgress?.(
+        `正在生成选项${optIndex + 1}：「${variantDescriptions[optIndex]}」...`,
+        chunkIndex + 1,
+        chunks.length,
+      )
+      
+      const variantHints = [
+        '',
+        '\n\n【变体要求】请采用更具冲突性的剧情走向，增加更多悬念和转折。',
+        '\n\n【变体要求】请采用更温和的剧情走向，注重角色情感发展和细节描写。',
+      ]
+      
+      const messages = buildChapterOutlinePrompt(
+        volume.title,
+        volume.summary,
+        worldContext,
+        prevChunkEnding,
+        `${userHint || ''}\n\n【分块约束】\n本块目标：${chunk.purpose}\n情绪基调：${chunk.emotionalTone}\n节奏：${chunk.pace}\n本块章节数：${chaptersInChunk}章\n本块章节范围：第${chunk.startChapter}-${chunk.endChapter}章\n\n【边界约束】\n1. 本块结束时，主角能力等级不能超过卷纲设定的上限\n2. 本块不能引入超过2个新角色\n3. 本块必须推进主线至少1个阶段\n4. 本块结束状态必须能够平滑过渡到下一块${variantHints[optIndex]}`,
+        {
+          parameterValues: {
+            chaptersPerVolume: chaptersInChunk,
+            pace: chunk.pace,
+          },
+        },
+        characterContext,
+        worldRulesContext,
+      )
+      
+      let rawOutput: string
+      try {
+        rawOutput = await chat(messages, config, { category: 'outline.chapter', projectId: volume.projectId })
+      } catch (err) {
+        console.error(`[ChunkedOutline] 块「${chunk.title}」选项${optIndex + 1}生成失败:`, err)
+        continue
+      }
+      
+      onProgress?.(
+        `正在解析选项${optIndex + 1}的章节结构...`,
+        chunkIndex + 1,
+        chunks.length,
+      )
+      
+      const parsed = await parseChapterOutlineSmart(rawOutput, config)
+      
+      onProgress?.(
+        `正在检测选项${optIndex + 1}的情节偏离度...`,
+        chunkIndex + 1,
+        chunks.length,
+      )
+      
+      const deviation = await analyzeDeviation(
+        volume.summary,
+        parsed,
+        worldRulesContext || '',
+      )
+      
+      let finalChapters = parsed
+      if (deviation.score > 60) {
+        onProgress?.(
+          `⚠️ 选项${optIndex + 1}情节偏离（偏离度${deviation.score}%），正在自动调整...`,
+          chunkIndex + 1,
+          chunks.length,
+        )
+        
+        const adjustedMessages = buildChapterOutlinePrompt(
+          volume.title,
+          volume.summary,
+          worldContext,
+          prevChunkEnding,
+          `${userHint || ''}\n\n【分块约束】\n本块目标：${chunk.purpose}\n情绪基调：${chunk.emotionalTone}\n节奏：${chunk.pace}\n本块章节数：${chaptersInChunk}章\n\n【挽救约束】\n检测到以下偏离：\n${deviation.warnings.join('\n')}\n\n请在保持情节合理性的前提下，将上述偏离修正，确保本块结束时能够回归卷纲设定的轨道。`,
+          {
+            parameterValues: {
+              chaptersPerVolume: chaptersInChunk,
+              pace: chunk.pace,
+            },
+          },
+          characterContext,
+          worldRulesContext,
+        )
+        
+        try {
+          rawOutput = await chat(adjustedMessages, config, { category: 'outline.chapter', projectId: volume.projectId })
+          const adjusted = await parseChapterOutlineSmart(rawOutput, config)
+          finalChapters = adjusted
+        } catch {
+        }
+      }
+      
+      chunkOptions.push({
+        id: `opt-${chunkIndex}-${optIndex}`,
+        chapters: finalChapters,
+        description: variantDescriptions[optIndex],
+        deviation: deviation,
+      })
+      
+      onProgress?.(
+        `选项${optIndex + 1}「${variantDescriptions[optIndex]}」完成（偏离度${deviation.score}%）`,
+        chunkIndex + 1,
+        chunks.length,
+      )
+    }
+    
+    let selectedOption: ChunkOption
+    
+    if (chunkOptions.length === 0) {
+      onProgress?.(
+        `⚠️ 块「${chunk.title}」所有选项生成失败，使用空章节继续`,
+        chunkIndex + 1,
+        chunks.length,
+      )
+      selectedOption = {
+        id: `opt-${chunkIndex}-0`,
+        chapters: [],
+        description: '默认',
+        deviation: {
+          score: 0,
+          dimensionScores: { plotGoal: 0, characterState: 0, worldConsistency: 0, foreshadowing: 0, mainLine: 0 },
+          warnings: [],
+          suggestions: [],
+        },
+      }
+    } else if (onChunkReady) {
+      onProgress?.(
+        `「${chunk.title}」已生成 ${chunkOptions.length} 个选项，请选择...`,
+        chunkIndex + 1,
+        chunks.length,
+      )
+      const result = await onChunkReady(chunk, chunkOptions)
+      selectedOption = result || chunkOptions[0]
+    } else {
+      selectedOption = chunkOptions[0]
+    }
+    
+    const renumbered = selectedOption.chapters.map((ch, idx) => ({
+      ...ch,
+      title: ch.title.replace(/第\d+章/, `第${allChapters.length + idx + 1}章`),
+    }))
+    
+    allChapters.push(...renumbered)
+    
+    if (renumbered.length > 0) {
+      prevChunkEnding = renumbered[renumbered.length - 1].summary
+    }
+    
+    onProgress?.(
+      `「${chunk.title}」完成（${renumbered.length}章）`,
+      chunkIndex + 1,
+      chunks.length,
+    )
+  }
+  
+  const finalChapters = allChapters.slice(0, targetChapterCount)
+  finalChapters.forEach((ch, idx) => {
+    ch.title = ch.title.replace(/第\d+章/, `第${idx + 1}章`)
+  })
+  
+  return finalChapters
+}
+
+export function getSalvageOptions(deviation: DeviationAnalysis): SalvageOption[] {
+  const options: SalvageOption[] = [
+    {
+      type: 'auto-adjust',
+      label: '自动微调',
+      description: '在后续章节中自然调整，不引入专门的挽救章节',
+    },
+  ]
+  
+  if (deviation.score > 60) {
+    options.push({
+      type: 'transition-chapters',
+      label: '生成过渡章节',
+      description: '添加专门的过渡章节，将情节拉回正轨',
+      estimatedAdditionalChapters: 2,
+    })
+  }
+  
+  options.push(
+    {
+      type: 'regenerate',
+      label: '重新生成',
+      description: '丢弃当前块，基于之前的状态重新生成',
+    },
+    {
+      type: 'ignore',
+      label: '忽略',
+      description: '继续当前方向（可能导致后续断层）',
+    },
+  )
+  
+  return options
+}
+
+export { generateChunks }

--- a/src/lib/editor/outline-beat-conflict.ts
+++ b/src/lib/editor/outline-beat-conflict.ts
@@ -1,0 +1,185 @@
+import type { DetailedOutline, EmotionBeatCard, ScenePace } from '../types'
+
+export interface ConflictWarning {
+  type: 'emotion' | 'structure' | 'location'
+  severity: 'warning' | 'conflict'
+  message: string
+  detail?: string
+}
+
+const EMOTION_CONFLICT_MAP: Record<string, string[]> = {
+  '紧张': ['平静', '温馨', '轻松'],
+  '悲伤': ['欢乐', '轻松', '热血'],
+  '愤怒': ['平静', '温馨', '悲伤'],
+  '恐惧': ['平静', '欢乐', '热血'],
+  '欢乐': ['悲伤', '恐惧', '愤怒'],
+  '平静': ['紧张', '愤怒', '恐惧'],
+  '温馨': ['悲伤', '愤怒', '恐惧'],
+  '震撼': ['平静', '温馨'],
+  '期待': ['悲伤', '恐惧'],
+  '热血': ['悲伤', '恐惧', '平静'],
+}
+
+function detectEmotionConflict(
+  detailed: DetailedOutline | undefined,
+  beatCard: EmotionBeatCard | undefined,
+): ConflictWarning[] {
+  const warnings: ConflictWarning[] = []
+  if (!detailed || !beatCard) return warnings
+
+  const scenesText = detailed.scenes.map(s => s.summary + ' ' + s.conflict).join(' ')
+  const beatsText = beatCard.beats.map(b => b.emotionTone + ' ' + b.readerFeeling).join(' ')
+
+  for (const [emotion, conflicts] of Object.entries(EMOTION_CONFLICT_MAP)) {
+    const hasEmotion = beatsText.includes(emotion)
+    const hasConflict = conflicts.some(c => scenesText.includes(c))
+    if (hasEmotion && hasConflict) {
+      warnings.push({
+        type: 'emotion',
+        severity: 'conflict',
+        message: `情感基调冲突：细纲中提到"${conflicts.find(c => scenesText.includes(c))}"，但情感节拍设定为"${emotion}"`,
+      })
+    }
+  }
+
+  const sceneCount = detailed.scenes.length
+  const beatCount = beatCard.beats.length
+  if (sceneCount > 0 && beatCount > 0 && Math.abs(sceneCount - beatCount) >= 2) {
+    warnings.push({
+      type: 'structure',
+      severity: 'warning',
+      message: `结构不匹配：细纲有 ${sceneCount} 个场景，情感节拍有 ${beatCount} 个节拍`,
+      detail: '建议调整为相近数量，便于一一对应',
+    })
+  }
+
+  const sceneLocations = new Set(detailed.scenes.filter(s => s.location).map(s => s.location))
+  const beatLocations = new Set(beatCard.beats.filter(b => b.sceneGoal?.includes('地点') || b.sceneGoal?.includes('在')).map(b => b.sceneGoal))
+
+  if (sceneLocations.size > 0 && beatLocations.size > 0) {
+    const allLocations = [...sceneLocations]
+    const beatsMentionOtherLoc = beatCard.beats.some(b =>
+      b.sceneGoal && !allLocations.some(loc => b.sceneGoal?.includes(loc))
+    )
+    if (beatsMentionOtherLoc) {
+      warnings.push({
+        type: 'location',
+        severity: 'warning',
+        message: '地点信息不一致：情感节拍中提到的地点与细纲场景地点可能不匹配',
+      })
+    }
+  }
+
+  return warnings
+}
+
+export function detectOutlineBeatConflicts(
+  detailed: DetailedOutline | undefined,
+  beatCard: EmotionBeatCard | undefined,
+): ConflictWarning[] {
+  if (!detailed || !beatCard) return []
+  if (detailed.scenes.length === 0 || beatCard.beats.length === 0) return []
+
+  return detectEmotionConflict(detailed, beatCard)
+}
+
+export function adaptOutlineToBeat(
+  detailed: DetailedOutline,
+  beatCard: EmotionBeatCard,
+): DetailedOutline {
+  const newScenes = [...detailed.scenes]
+  const beatCount = beatCard.beats.length
+  const sceneCount = newScenes.length
+
+  if (beatCount > sceneCount) {
+    for (let i = sceneCount; i < beatCount; i++) {
+      const beat = beatCard.beats[i]
+      newScenes.push({
+        sceneId: `scene-${Date.now()}-${i}`,
+        title: beat.sceneGoal || `场景${i + 1}`,
+        summary: beat.sceneGoal || '根据情感节拍生成的场景',
+        location: '',
+        conflict: '',
+        pace: beat.emotionTone.includes('紧张') || beat.emotionTone.includes('热血') ? 'fast' as ScenePace : 'medium',
+        characterIds: [],
+        estimatedWords: 1500,
+        notes: '',
+      })
+    }
+  } else if (beatCount < sceneCount) {
+    newScenes.splice(beatCount)
+  }
+
+  newScenes.forEach((scene, idx) => {
+    if (idx < beatCard.beats.length) {
+      const beat = beatCard.beats[idx]
+      if (beat.emotionTone) {
+        if (beat.emotionTone.includes('紧张') || beat.emotionTone.includes('热血')) {
+          scene.pace = 'fast' as ScenePace
+        } else if (beat.emotionTone.includes('悲伤') || beat.emotionTone.includes('平静')) {
+          scene.pace = 'slow' as ScenePace
+        } else {
+          scene.pace = 'medium' as ScenePace
+        }
+      }
+    }
+  })
+
+  return { ...detailed, scenes: newScenes }
+}
+
+export function adaptBeatToOutline(
+  beatCard: EmotionBeatCard,
+  detailed: DetailedOutline,
+): EmotionBeatCard {
+  const newBeats = [...beatCard.beats]
+  const sceneCount = detailed.scenes.length
+  const beatCount = newBeats.length
+
+  if (sceneCount > beatCount) {
+    for (let i = beatCount; i < sceneCount; i++) {
+      const scene = detailed.scenes[i]
+      let emotionTone = '平静'
+      let readerFeeling = '中性'
+
+      if (scene.pace === 'fast') {
+        emotionTone = '紧张'
+        readerFeeling = '紧张'
+      } else if (scene.pace === 'slow') {
+        emotionTone = '平静'
+        readerFeeling = '平和'
+      } else {
+        emotionTone = '期待'
+        readerFeeling = '期待'
+      }
+
+      newBeats.push({
+        label: `节拍${i + 1}`,
+        sceneGoal: scene.title || '场景目标',
+        emotionTone,
+        readerFeeling,
+        characterGrowth: '',
+      })
+    }
+  } else if (sceneCount < beatCount) {
+    newBeats.splice(sceneCount)
+  }
+
+  newBeats.forEach((beat, idx) => {
+    if (idx < detailed.scenes.length) {
+      const scene = detailed.scenes[idx]
+      beat.label = `节拍${idx + 1}`
+      beat.sceneGoal = scene.title || beat.sceneGoal
+
+      if (scene.pace === 'fast') {
+        beat.emotionTone = beat.emotionTone.includes('紧张') || beat.emotionTone.includes('热血') ? beat.emotionTone : '紧张'
+        beat.readerFeeling = '紧张'
+      } else if (scene.pace === 'slow') {
+        beat.emotionTone = beat.emotionTone.includes('平静') || beat.emotionTone.includes('悲伤') ? beat.emotionTone : '平静'
+        beat.readerFeeling = '平和'
+      }
+    }
+  })
+
+  return { ...beatCard, beats: newBeats }
+}

--- a/src/pages/WorkspacePage.tsx
+++ b/src/pages/WorkspacePage.tsx
@@ -61,6 +61,7 @@ const FactLibraryPanel = lazy(() => import('../components/facts/FactLibraryPanel
 const StoryTimelinePanel = lazy(() => import('../components/timeline/StoryTimelinePanel'))
 const SceneVerifyPanel = lazy(() => import('../components/scene/SceneVerifyPanel'))
 const WorldGroupOverview = lazy(() => import('../components/world-group/WorldGroupOverview'))
+const GlobalReplacePanel = lazy(() => import('../components/tools/GlobalReplacePanel'))
 import { useLocationStore } from '../stores/location'
 import { useWorldGroupStore } from '../stores/world-group'
 
@@ -255,6 +256,8 @@ export default function WorkspacePage() {
         />
       case 'scene-verify':
         return <SceneVerifyPanel project={project} />
+      case 'global-replace':
+        return <GlobalReplacePanel project={project} />
 
       // 作品学习已整合进项目参考 → 深度分析 tab（Phase 20）
       case 'master-studies':


### PR DESCRIPTION
## 功能概述

### 1. 全局替换
- 独立的全局替换工具，支持在设定词条、角色、世界规则和章节正文中进行查找替换
- 支持全局正则替换，一次性替换所有匹配项

### 2. 设定 AI 问答
- 设定查询面板新增 AI 问答模式
- 支持多轮对话、流式输出
- 可临时补充设定后继续提问，支持将讨论结果整理加入设定

### 3. 分块章纲 n选一
- 将章纲生成分成 5 个块（setup 15%、development 25%、pre-climax 30%、climax 20%、resolution 10%）
- 每块生成 3 个剧情走向供用户选择
- 用户选择后，下一块基于选择的走向继续生成
- 支持偏差检测和挽救机制

## 修改文件

**新增文件**：
- `src/components/tools/GlobalReplacePanel.tsx` - 全局替换面板
- `src/components/editor/SettingLookupPanel.tsx` - 设定查询与 AI 问答面板
- `src/components/outline/ChunkOptionDialog.tsx` - 分块章纲选项对话框
- `src/components/outline/ChunkPreviewPanel.tsx` - 分块预览面板
- `src/components/outline/GenerationProgressPanel.tsx` - 生成进度面板
- `src/lib/ai/chunked-chapter-generator.ts` - 分块章纲生成器
- `src/lib/editor/outline-beat-conflict.ts` - 细纲与节拍冲突处理

**修改文件**：
- `src/components/layout/sidebar-tree.ts` - 添加全局替换入口
- `src/pages/WorkspacePage.tsx` - 注册全局替换面板路由