### PR TITLE
增加 Cloudflare Pages 云端部署支持

### DIFF
--- a/docs/MASTER-BLUEPRINT.md
+++ b/docs/MASTER-BLUEPRINT.md
@@ -90,7 +90,7 @@
 | 当前事实 | 数值 | 单一事实源 |
 |---|---:|---|
 | 应用语义版本 | `3.8.0` | `package.json` |
-| TypeScript 生产源码 | 406 个文件 / 77432 行 | `tsconfig.json` |
+| TypeScript 生产源码 | 406 个文件 / 77428 行 | `tsconfig.json` |
 | IndexedDB schema | v38 / 42 张 required tables | `schema.ts` / `REQUIRED_TABLES` |
 | PROJECT_TABLES | 42 张表 | `project-tables.ts` |
 | Prompt 主线 | 59 个 moduleKey / 204 条内置模板 | `PromptModuleKey` / `prompt-seeds*.ts` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
+        "@tiptap/core": "^3.28.0",
         "@tiptap/extension-placeholder": "^3.28.0",
         "@tiptap/extension-text-style": "^3.28.0",
         "@tiptap/pm": "^3.28.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ci:e2e": "npm run test:e2e"
   },
   "dependencies": {
+    "@tiptap/core": "^3.28.0",
     "@tiptap/extension-placeholder": "^3.28.0",
     "@tiptap/extension-text-style": "^3.28.0",
     "@tiptap/pm": "^3.28.0",

--- a/src/lib/safety/require-backup-before.ts
+++ b/src/lib/safety/require-backup-before.ts
@@ -185,9 +185,32 @@ function confirmFallback(options: SafetyConfirmOptions): Promise<boolean> {
   return Promise.resolve(globalThis.confirm(lines))
 }
 
+export type TestEnvSignals = {
+  /** Vitest 注入的 import.meta.env.VITEST；`vite --mode test` 不会设置 */
+  vitestFlag?: boolean
+  /** Node/happy-dom 的 process.env（经 globalThis 读取，不引入 @types/node） */
+  processEnv?: Record<string, string | undefined>
+}
+
 /**
- * 测试环境检测（vitest 下 Vite 会把 import.meta.env.MODE 设为 'test'）。
+ * 纯判定：是否处于自动化测试运行时。
+ *
+ * 不能只靠 import.meta.env.MODE === 'test'：真实浏览器跑 `vite --mode test`
+ * 也会把 MODE 设为 test，从而误跳过高危操作的备份/二次确认。
  */
+export function detectTestEnv(signals: TestEnvSignals): boolean {
+  if (signals.vitestFlag) return true
+  if (signals.processEnv?.VITEST) return true
+  return signals.processEnv?.NODE_ENV === 'test'
+}
+
 function isTestEnv(): boolean {
-  return import.meta.env.MODE === 'test'
+  const processLike = (globalThis as {
+    process?: { env?: Record<string, string | undefined> }
+  }).process
+
+  return detectTestEnv({
+    vitestFlag: Boolean(import.meta.env.VITEST),
+    processEnv: processLike?.env,
+  })
 }

--- a/src/lib/safety/require-backup-before.ts
+++ b/src/lib/safety/require-backup-before.ts
@@ -186,12 +186,8 @@ function confirmFallback(options: SafetyConfirmOptions): Promise<boolean> {
 }
 
 /**
- * 测试环境检测(vitest 自动设置 NODE_ENV=test;happy-dom 中 process 可用)。
+ * 测试环境检测（vitest 下 Vite 会把 import.meta.env.MODE 设为 'test'）。
  */
 function isTestEnv(): boolean {
-  try {
-    return typeof process !== 'undefined' && process.env?.NODE_ENV === 'test'
-  } catch {
-    return false
-  }
+  return import.meta.env.MODE === 'test'
 }


### PR DESCRIPTION
## 改动说明 / What & Why

<!-- 这个 PR 做了什么,为什么 -->

修复两处会阻断 `pnpm build` / Vite 启动的问题： 

1. 使用 pnpm dev 环境时部分页面访问会报错: 因为`@tiptap/react` / `starter-kit` 的传递依赖。pnpm 严格隔离下不会提升到 `node_modules/@tiptap/core`，导致 Vite import-analysis 报错。

2. 使用Cloudflare Pages时部署报错, 原因`require-backup-before.ts` 的 `isTestEnv()` 使用了 Node 的 `process.env.NODE_ENV`，而前端 `tsconfig` 未引入 `@types/node`

补充Cloudflare Pages部署方案, 作者可以加入文档里:

1. 在Github Fork项目, 打开 Workers & Pages
2. Create → Pages → Import an existing Git repository 
3. 选 storyforge 仓库
4. 构建命令: npm run build && mkdir -p out/storyforge && cp -R dist/* out/storyforge/
5. 输出目录选择 out

<img width="403" height="605" alt="图片" src="https://github.com/user-attachments/assets/75d2e425-5cc9-4453-8b3c-6cd0eafd35ff" />

在线演示: [sf.io0.cc](https://sf.io0.cc/storyforge/)

补充建议, 访问路径为什么不能直接用 / 呢? 在线部署时候还要额外加一个 /storyforge


<!-- Closes #N -->

## 自检清单 / Checklist

- [x] 已读 `CLAUDE.md`,改动遵循三注册表铁律(未直接调 db / 未手挑上下文 / 未手写表清单)
- [x] `npm run ci` 本地全绿(check:required-tables / check:ai-manual / check:architecture / tsc / test / build)
- [x] 若改了 DB schema:已写迁移测试 + 真实数据实测
- [x] 若加了表/字段/上下文源/AI 动作:已同步对应注册表
- [x] 若改了 AI 行为:已跑 `npm run gen:ai-manual` 重新生成说明书
- [x] 修 bug 的:已有一条会失败→变绿的反例测试
