### PR TITLE
Refactor/prompt library grid layout

### DIFF
--- a/src/components/character/CharacterPanel.tsx
+++ b/src/components/character/CharacterPanel.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect } from 'react'
 import {
-  Plus, Sparkles, ChevronDown,
+  Plus, Sparkles, Trash2, ChevronDown, ChevronRight,
+  CheckSquare, Square, X,
 } from 'lucide-react'
+import { useDialog } from '../shared/Dialog'
+import { useToast } from '../shared/Toast'
+import { InlineInput, InlineTextarea } from '../shared/InlineEdit'
 import { CInput } from '../shared/CompositionInput'
 import { useCharacterStore } from '../../stores/character'
 import { useWorldGroupStore } from '../../stores/world-group'
@@ -17,10 +21,12 @@ import PromptRunPanel from '../shared/PromptRunPanel'
 import type {
   Project, Character, CharacterMoralAxis, CharacterOrderAxis, CharacterRoleWeight,
 } from '../../lib/types'
+import CharacterStatusPanel from './CharacterStatusPanel'
 import CharacterDimensionPicker from './CharacterDimensionPicker'
+import CharacterDimensionFields from './CharacterDimensionFields'
+import CharacterSupplementAction from './CharacterSupplementAction'
 import { CHARACTER_DIMENSIONS, type CharacterDimensionKey } from '../../lib/character/character-dimensions'
 import CharacterAxesPicker from './CharacterAxesPicker'
-import CharacterDetailCard from './CharacterDetailCard'
 import {
   MORAL_AXIS_LABELS,
   ORDER_AXIS_LABELS,
@@ -51,9 +57,16 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
   const { characters, loadAll, addCharacter, updateCharacter, deleteCharacter } = useCharacterStore()
   const { groups, activeGroupId } = useWorldGroupStore()
   const { config: aiConfig } = useAIConfigStore()
+  const dialog = useDialog()
+  const toast = useToast()
   const [selected, setSelected] = useState<number | null>(null)
   const [hint, setHint] = useState('')
   const [parsing, setParsing] = useState(false)
+  // 角色多选删除
+  const [multiSelectMode, setMultiSelectMode] = useState(false)
+  const [selectedCharIds, setSelectedCharIds] = useState<Set<number>>(new Set())
+  // 戏份分类过滤：'all' | 'main' | 'secondary' | 'npc' | 'extra'
+  const [roleFilter, setRoleFilter] = useState<'all' | CharacterRoleWeight>('all')
   const [showRolePicker, setShowRolePicker] = useState(false)
   const [draftAxes, setDraftAxes] = useState<{
     roleWeight: CharacterRoleWeight | null
@@ -82,9 +95,12 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
     : worldFilter === 'cross'
       ? characters.filter(c => c.isCrossWorld)
       : characters.filter(c => c.isCrossWorld || c.homeWorldGroupId === worldFilter)
+  // 戏份分类过滤：view='main' 永远只看主要角色；generator 模式受 roleFilter 控制
   const displayedChars = view === 'main'
     ? filterCharactersByRoleWeight(worldFilteredChars, 'main')
-    : worldFilteredChars
+    : roleFilter === 'all'
+      ? worldFilteredChars
+      : worldFilteredChars.filter(c => c.roleWeight === roleFilter)
 
   const selectedChar = characters.find(c => c.id === selected)
 
@@ -115,6 +131,53 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
 
   const handleUpdate = (field: keyof Character, value: string) => {
     if (selectedChar?.id) updateCharacter(selectedChar.id, { [field]: value })
+  }
+
+  // ── 多选删除：角色 ──
+
+  const toggleCharSelect = (id: number) => {
+    setSelectedCharIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleCharSelectAll = () => {
+    setSelectedCharIds(prev => {
+      if (prev.size === displayedChars.length && displayedChars.length > 0) return new Set()
+      return new Set(displayedChars.map(c => c.id!))
+    })
+  }
+
+  const handleEnterMultiSelect = () => {
+    setMultiSelectMode(true)
+    setSelectedCharIds(new Set())
+    setSelected(null)
+  }
+
+  const handleExitMultiSelect = () => {
+    setMultiSelectMode(false)
+    setSelectedCharIds(new Set())
+  }
+
+  const handleBatchDeleteCharacters = async () => {
+    if (selectedCharIds.size === 0) return
+    const ok = await dialog.confirm({
+      title: `删除选中的 ${selectedCharIds.size} 个角色？`,
+      message: '这些角色及其关联数据将被删除，此操作不可恢复。',
+      confirmText: '删除',
+      tone: 'danger',
+    })
+    if (!ok) return
+    const ids = Array.from(selectedCharIds)
+    for (const id of ids) {
+      deleteCharacter(id)
+    }
+    setSelectedCharIds(new Set())
+    setMultiSelectMode(false)
+    toast.success(`已删除 ${ids.length} 个角色。`)
   }
 
   const handleAIGenerate = async () => {
@@ -215,7 +278,7 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
               </div>
               <button
                 onClick={handleAIGenerate}
-                disabled={ai.isStreaming}
+                disabled={ai.isStreaming || multiSelectMode}
                 className="flex items-center gap-1.5 px-3 py-2 bg-bg-elevated text-text-secondary text-sm rounded-md hover:text-accent disabled:opacity-50 transition-colors border border-border hover:border-accent/50"
               >
                 <Sparkles className="w-3.5 h-3.5" /> AI 设计角色
@@ -223,10 +286,85 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
             </div>
           </>
         )}
+        {/* 多选删除按钮 / 退出多选 */}
+        {displayedChars.length > 0 && (
+          !multiSelectMode ? (
+            <button
+              onClick={handleEnterMultiSelect}
+              className="flex items-center gap-1 px-2.5 py-2 text-xs text-text-secondary hover:text-error border border-border rounded-md transition-colors"
+              title="进入多选删除"
+            >
+              <CheckSquare className="w-3.5 h-3.5" /> 多选删除
+            </button>
+          ) : (
+            <button
+              onClick={handleExitMultiSelect}
+              className="flex items-center gap-1 px-2.5 py-2 text-xs text-text-secondary hover:text-text-primary border border-border rounded-md transition-colors"
+            >
+              <X className="w-3.5 h-3.5" /> 退出多选
+            </button>
+          )
+        )}
         <span className="text-xs text-text-muted ml-auto">
           {view === 'main' ? '主要角色' : '角色生成'} · {displayedChars.length}
         </span>
       </div>
+
+      {/* 多选模式操作栏 */}
+      {multiSelectMode && (
+        <div className="flex items-center justify-between gap-2 px-3 py-2 bg-bg-surface border border-border rounded-md">
+          <button
+            onClick={toggleCharSelectAll}
+            disabled={displayedChars.length === 0}
+            className="flex items-center gap-1.5 px-2 py-1 text-xs text-text-secondary hover:text-accent disabled:opacity-40"
+          >
+            {selectedCharIds.size === displayedChars.length && displayedChars.length > 0
+              ? <CheckSquare className="w-3.5 h-3.5 text-accent" />
+              : <Square className="w-3.5 h-3.5 text-text-muted" />}
+            {selectedCharIds.size === displayedChars.length && displayedChars.length > 0 ? '取消全选' : '全选'}
+          </button>
+          <span className="text-xs text-text-muted">已选 {selectedCharIds.size}/{displayedChars.length}</span>
+          <button
+            onClick={handleBatchDeleteCharacters}
+            disabled={selectedCharIds.size === 0}
+            className="flex items-center gap-1 px-2 py-1 text-xs text-error bg-error/10 border border-error/40 rounded hover:bg-error/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <Trash2 className="w-3.5 h-3.5" /> 删除选中 ({selectedCharIds.size})
+          </button>
+        </div>
+      )}
+
+      {/* 戏份分类过滤（仅 generator 模式） */}
+      {view === 'generator' && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {(['all', 'main', 'secondary', 'npc', 'extra'] as const).map(key => {
+            const labelMap: Record<typeof key, string> = {
+              all: '全部',
+              main: '主要',
+              secondary: '次要',
+              npc: 'NPC',
+              extra: '路人',
+            }
+            const count = key === 'all'
+              ? worldFilteredChars.length
+              : worldFilteredChars.filter(c => c.roleWeight === key).length
+            const active = roleFilter === key
+            return (
+              <button
+                key={key}
+                onClick={() => setRoleFilter(key)}
+                className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
+                  active
+                    ? 'bg-accent text-white border-accent'
+                    : 'bg-bg-base text-text-secondary border-border hover:border-accent/50'
+                }`}
+              >
+                {labelMap[key]} <span className="opacity-70">({count})</span>
+              </button>
+            )
+          })}
+        </div>
+      )}
 
       {/* 多世界：世界过滤器 */}
       {project.enableMultiWorld && groups.length > 1 && (
@@ -330,7 +468,7 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
         />
       )}
 
-      {/* 主体：左侧列表 + 右侧详情 */}
+      {/* 主体：响应式六列网格 + 详情弹窗 */}
       {displayedChars.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-text-muted gap-3">
           <div className="text-4xl opacity-20">📖</div>
@@ -339,29 +477,45 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
           </p>
         </div>
       ) : (
-        <div className="flex gap-4">
-          {/* 左侧角色列表 */}
-          <div className="w-40 shrink-0 space-y-0.5">
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
             {displayedChars.map((c, i) => {
-              const active = selected === c.id
               const colorClass = GLYPH_COLORS[i % GLYPH_COLORS.length]
+              const checked = c.id != null && selectedCharIds.has(c.id)
               return (
                 <button
                   key={c.id}
-                  onClick={() => setSelected(active ? null : c.id!)}
-                  className={`w-full flex items-center gap-2.5 px-2 py-2 rounded-lg text-left transition-all ${
-                    active
-                      ? 'bg-accent/8 border-l-2 border-accent'
-                      : 'hover:bg-bg-hover border-l-2 border-transparent'
+                  onClick={() => {
+                    if (multiSelectMode) {
+                      if (c.id != null) toggleCharSelect(c.id)
+                    } else {
+                      setSelected(c.id!)
+                    }
+                  }}
+                  className={`relative text-left p-2 rounded-lg border transition-all ${
+                    multiSelectMode && checked
+                      ? 'border-accent ring-1 ring-accent/40 bg-accent/5'
+                      : 'border-border hover:border-accent/40 hover:bg-bg-hover'
                   }`}
                 >
-                  <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shrink-0 ${colorClass}`}>
-                    {c.name.charAt(0)}
-                  </span>
-                  <div className="min-w-0">
-                    <p className={`text-sm font-medium truncate ${active ? 'text-accent' : 'text-text-primary'}`}>{c.name}</p>
-                    <p className="text-[10px] text-text-muted truncate">
-                      {c.shortDescription?.slice(0, 10) || `${ROLE_WEIGHT_LABELS[c.roleWeight]} · ${MORAL_AXIS_LABELS[c.moralAxis]}`}
+                  {/* 多选模式下右上角复选框 */}
+                  {multiSelectMode && (
+                    <span className="absolute top-1 right-1 z-10">
+                      {checked
+                        ? <CheckSquare className="w-4 h-4 text-accent" />
+                        : <Square className="w-4 h-4 text-text-muted" />}
+                    </span>
+                  )}
+                  <div className="flex flex-col items-center text-center">
+                    <span className={`w-10 h-10 rounded-full flex items-center justify-center text-base font-bold shrink-0 ${colorClass}`}>
+                      {c.name.charAt(0)}
+                    </span>
+                    <p className="mt-1 text-xs font-medium truncate w-full text-text-primary">{c.name}</p>
+                    <p className="text-[10px] text-text-muted truncate w-full">
+                      {ROLE_WEIGHT_LABELS[c.roleWeight]} · {ORDER_AXIS_LABELS[c.orderAxis]}{MORAL_AXIS_LABELS[c.moralAxis]}
+                    </p>
+                    <p className="text-[10px] text-text-muted/80 line-clamp-2 w-full leading-tight mt-0.5 min-h-[2.4em]">
+                      {c.shortDescription || '—'}
                     </p>
                   </div>
                 </button>
@@ -369,25 +523,186 @@ export default function CharacterPanel({ project, view = 'generator' }: Props) {
             })}
           </div>
 
-          {/* 右侧详情卡 */}
-          <div className="flex-1 min-w-0">
-            {selectedChar ? (
-              <CharacterDetailCard
-                char={selectedChar}
-                glyphColor={GLYPH_COLORS[characters.findIndex(c => c.id === selectedChar.id) % GLYPH_COLORS.length]}
-                projectId={project.id!}
-                onUpdateField={handleUpdate}
-                onPatch={patch => updateCharacter(selectedChar.id!, patch)}
-                onReload={() => loadAll(project.id!)}
-                onDelete={() => { deleteCharacter(selectedChar.id!); setSelected(null) }}
-                multiWorld={!!project.enableMultiWorld}
-                worldGroups={groups}
-              />
-            ) : (
-              <div className="flex items-center justify-center h-64 text-text-muted text-sm">
-                ← 选择一个角色查看详情
+          {/* 详情弹窗 */}
+          {selectedChar && !multiSelectMode && (
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+              onClick={() => setSelected(null)}
+            >
+              <div
+                className="relative bg-bg-base border border-border rounded-lg shadow-xl w-full max-w-3xl max-h-[85vh] flex flex-col"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {/* 弹窗头：标题 + 关闭 */}
+                <div className="flex items-center justify-between px-4 py-2 border-b border-border shrink-0">
+                  <span className="text-sm font-medium text-text-primary">角色详情</span>
+                  <button
+                    onClick={() => setSelected(null)}
+                    className="p-1 text-text-muted hover:text-text-primary rounded transition-colors"
+                    title="关闭"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+                {/* 弹窗内容：独立滚动 */}
+                <div className="overflow-y-auto p-4">
+                  <CharacterDetailCard
+                    char={selectedChar}
+                    charIndex={characters.findIndex(c => c.id === selectedChar.id)}
+                    projectId={project.id!}
+                    onUpdate={handleUpdate}
+                    onDelete={() => { deleteCharacter(selectedChar.id!); setSelected(null) }}
+                    multiWorld={!!project.enableMultiWorld}
+                    worldGroups={groups}
+                  />
+                </div>
               </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── 角色详情卡（design 风格） ────────────────────────────────────
+
+function CharacterDetailCard({
+  char, charIndex, projectId, onUpdate, onDelete, multiWorld, worldGroups,
+}: {
+  char: Character
+  charIndex: number
+  projectId: number
+  onUpdate: (f: keyof Character, v: string) => void
+  onDelete: () => void
+  multiWorld?: boolean
+  worldGroups?: import('../../lib/types').WorldGroup[]
+}) {
+  const { updateCharacter, loadAll } = useCharacterStore()
+  const [expanded, setExpanded] = useState(true)
+  const glyphColor = GLYPH_COLORS[charIndex % GLYPH_COLORS.length]
+
+  return (
+    <div className="space-y-4">
+      {/* 头部：大号首字 + 名字 + 标签 */}
+      <div className="flex items-start gap-4">
+        {/* 大号首字 */}
+        <div className={`w-16 h-16 rounded-xl flex items-center justify-center text-3xl font-serif font-bold shrink-0 ${glyphColor}`}>
+          {char.name.charAt(0)}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          {/* 角色元信息行 */}
+          <div className="flex items-center gap-1.5 text-xs text-text-muted mb-0.5">
+            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium border border-border bg-bg-elevated text-text-secondary">
+              {ROLE_WEIGHT_LABELS[char.roleWeight]}
+            </span>
+            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium border border-border bg-bg-elevated text-text-secondary">
+              {ORDER_AXIS_LABELS[char.orderAxis]}{MORAL_AXIS_LABELS[char.moralAxis]}
+            </span>
+
+            {/* 多世界：归属世界 + 跨世界标记 */}
+            {multiWorld && (
+              <>
+                <select
+                  value={char.isCrossWorld ? 'cross' : (char.homeWorldGroupId ?? '')}
+                  onChange={e => {
+                    if (!char.id) return
+                    const v = e.target.value
+                    if (v === 'cross') {
+                      updateCharacter(char.id, { isCrossWorld: true, homeWorldGroupId: null })
+                    } else {
+                      updateCharacter(char.id, { isCrossWorld: false, homeWorldGroupId: v ? Number(v) : null })
+                    }
+                  }}
+                  className="px-1.5 py-0.5 bg-bg-elevated text-text-secondary text-[10px] rounded border border-border focus:outline-none focus:border-accent cursor-pointer"
+                  title="角色所属世界"
+                >
+                  <option value="cross">🌐 跨世界</option>
+                  {(worldGroups || []).map(g => (
+                    <option key={g.id} value={g.id}>{g.icon || '🌐'} {g.name}</option>
+                  ))}
+                </select>
+              </>
             )}
+          </div>
+
+          {/* 名字（可编辑） */}
+          <InlineInput
+            value={char.name}
+            onChange={v => onUpdate('name', v)}
+            className="text-2xl font-bold font-serif text-text-primary"
+          />
+
+          {/* 一句话简介（引号样式） */}
+          {char.shortDescription ? (
+            <InlineInput
+              value={char.shortDescription}
+              onChange={v => onUpdate('shortDescription', v)}
+              className="text-sm text-text-secondary mt-1 italic"
+              prefix={"“"}
+              suffix={"”"}
+              placeholder="点击添加一句话简介…"
+            />
+          ) : (
+            <InlineInput
+              value=""
+              onChange={v => onUpdate('shortDescription', v)}
+              className="text-sm text-text-muted mt-1 italic"
+              placeholder="点击添加一句话简介…"
+            />
+          )}
+        </div>
+
+        {/* 操作按钮 */}
+        <div className="flex items-center gap-1 shrink-0">
+          <CharacterSupplementAction
+            character={char}
+            projectId={projectId}
+            worldGroupId={char.homeWorldGroupId ?? null}
+            onDone={() => loadAll(projectId)}
+          />
+          <button onClick={() => setExpanded(!expanded)} className="p-1.5 text-text-muted hover:text-text-primary rounded transition-colors">
+            {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          </button>
+          <button onClick={onDelete} className="p-1.5 text-text-muted hover:text-error rounded transition-colors">
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <CharacterAxesPicker
+        roleWeight={char.roleWeight}
+        moralAxis={char.moralAxis}
+        orderAxis={char.orderAxis}
+        onChange={axes => {
+          if (!char.id || !axes.roleWeight || !axes.moralAxis || !axes.orderAxis) return
+          updateCharacter(char.id, axes as Pick<Character, 'roleWeight' | 'moralAxis' | 'orderAxis'>)
+        }}
+        compact
+      />
+
+      {/* Phase 23.1: 动态状态面板 */}
+      <CharacterStatusPanel projectId={projectId} characterName={char.name} />
+
+      {/* 完整维度（含 A 扩充的 13 维）——与 NPC/次要同源渲染，主角生成/补全的内容都看得见、能改 */}
+      {expanded && (
+        <div className="space-y-4">
+          <CharacterDimensionFields
+            character={char}
+            onChange={patch => { if (char.id) updateCharacter(char.id, patch) }}
+            exclude={['shortDescription']}
+          />
+          {/* 人物关系非 CHARACTER_DIMENSIONS 成员（由关系网单独管），单列保留，避免丢失 */}
+          <div className="flex gap-2">
+            <span className="w-20 flex-shrink-0 pt-1.5 text-xs text-text-muted">人物关系</span>
+            <div className="flex-1 min-w-0">
+              <InlineTextarea
+                value={char.relationships || ''}
+                onChange={v => onUpdate('relationships', v)}
+                placeholder="点击填写人物关系…"
+              />
+            </div>
           </div>
         </div>
       )}

--- a/src/components/outline/OutlinePanel.tsx
+++ b/src/components/outline/OutlinePanel.tsx
@@ -1,37 +1,127 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import type { DragEvent as ReactDragEvent } from 'react'
+import { Plus, Trash2, Sparkles, ChevronRight, ChevronDown, Check, X, LayoutList, Layers, Loader2, GripVertical, CornerDownRight, CheckSquare, Square } from 'lucide-react'
 import { useOutlineStore } from '../../stores/outline'
+import { useDragReorder, type ItemDnD } from './useDragReorder'
 import { useWorldGroupStore } from '../../stores/world-group'
 import { useAIStream } from '../../hooks/useAIStream'
 import { createAISessionKey } from '../../stores/ai-generation-session'
+import {
+  buildVolumeOutlinePrompt,
+  buildChapterOutlinePrompt,
+  buildSingleChapterOutlinePrompt,
+} from '../../lib/ai/adapters/outline-adapter'
 import { assembleContext } from '../../lib/registry/assemble-context'
 import {
   parseVolumeOutlineSmart, parseChapterOutlineSmart,
   type ParsedVolume, type ParsedChapter,
 } from '../../lib/ai/parse-outline-output'
 import { useAIConfigStore } from '../../stores/ai-config'
-import { getTopLevelVolumes } from '../../lib/outline/selectors'
+import { runBatchOutlineGeneration, type BatchOutlineProgress } from '../../lib/ai/batch-outline-runner'
+import { adopt } from '../../lib/registry/adopt'
+import { getTopLevelVolumes, estimateChaptersPerVolume, DEFAULT_WORDS_PER_CHAPTER } from '../../lib/outline/selectors'
 import { normalizeOutlineNode } from '../../lib/outline/normalize'
-import { adoptGeneratedOutlineItems, adoptGeneratedOutlineSummary } from '../../lib/outline/adopt-generation'
+import type { AssembleContextResult } from '../../lib/registry/types'
+import AIStreamOutput from '../shared/AIStreamOutput'
 import PromptRunPanel from '../shared/PromptRunPanel'
 import PanelLayout from '../shared/PanelLayout'
+import AutoResizeTextarea from '../shared/AutoResizeTextarea'
 import { CInput } from '../shared/CompositionInput'
 import { useDialog } from '../shared/Dialog'
 import { useToast } from '../shared/Toast'
 import type { Project, StoryStructure } from '../../lib/types'
 import { STORY_STRUCTURES } from '../../lib/types/outline'
-import OutlineVolumeSidebar from './OutlineVolumeSidebar'
-import OutlineVolumeDetail from './OutlineVolumeDetail'
-import OutlineGenerationRequestPanel from './OutlineGenerationRequestPanel'
-import OutlineGenerationResultPanel from './OutlineGenerationResultPanel'
-import { useOutlineBatchGeneration } from './useOutlineBatchGeneration'
-import { useOutlineGenerationController } from './useOutlineGenerationController'
-import { useOutlineChapterCountEstimate } from './useOutlineChapterCountEstimate'
-import { useOutlineChapterDrag } from './useOutlineChapterDrag'
-import { decodeGenerationOperation } from '../../lib/outline/generation-request'
+
+const OUTLINE_CHAPTER_DRAG_MIME = 'application/x-storyforge-outline-chapter'
+
+interface ChapterDragPayload {
+  chapterId: number
+  sourceParentId: number | null
+}
+
+function readChapterDragPayload(event: ReactDragEvent): ChapterDragPayload | null {
+  const raw = event.dataTransfer?.getData(OUTLINE_CHAPTER_DRAG_MIME) ?? ''
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<ChapterDragPayload>
+    const chapterId = Number(parsed.chapterId)
+    const sourceParentId = parsed.sourceParentId == null ? null : Number(parsed.sourceParentId)
+    if (!Number.isFinite(chapterId)) return null
+    if (sourceParentId != null && !Number.isFinite(sourceParentId)) return null
+    return { chapterId, sourceParentId }
+  } catch {
+    const legacyId = Number(raw)
+    return Number.isFinite(legacyId) ? { chapterId: legacyId, sourceParentId: null } : null
+  }
+}
+
+function hasChapterDragPayload(event: ReactDragEvent): boolean {
+  return Array.from(event.dataTransfer?.types ?? []).includes(OUTLINE_CHAPTER_DRAG_MIME)
+}
+
+type GetActiveChapterDrag = () => ChapterDragPayload | null
+
+export function chapterDropProps({
+  targetParentId,
+  targetIndex,
+  onMoveChapter,
+  getActiveChapterDrag,
+  clearActiveChapterDrag,
+}: {
+  targetParentId: number
+  targetIndex: number
+  onMoveChapter: (chapterId: number, targetParentId: number, index: number) => Promise<void>
+  getActiveChapterDrag: GetActiveChapterDrag
+  clearActiveChapterDrag: () => void
+}) {
+  return {
+    onDragOver: (event: ReactDragEvent) => {
+      if (!getActiveChapterDrag() && !hasChapterDragPayload(event)) return
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'move'
+    },
+    onDrop: async (event: ReactDragEvent) => {
+      const payload = readChapterDragPayload(event) ?? getActiveChapterDrag()
+      if (!payload) return
+      event.preventDefault()
+      event.stopPropagation()
+      try {
+        await onMoveChapter(payload.chapterId, targetParentId, targetIndex)
+      } finally {
+        clearActiveChapterDrag()
+      }
+    },
+  }
+}
 
 interface Props {
   project: Project
   onOpenChapter?: (nodeId: number) => void
+}
+
+type OutlineGenerationRequest =
+  | { kind: 'volumes' }
+  | { kind: 'chapters'; volumeId: number }
+  | { kind: 'single-volume'; volumeId: number }
+  | { kind: 'single-chapter'; chapterId: number }
+
+function encodeGenerationOperation(request: OutlineGenerationRequest): string {
+  if (request.kind === 'volumes') return 'outline.volume:batch'
+  if (request.kind === 'chapters') return `outline.chapter:batch:${request.volumeId}`
+  if (request.kind === 'single-volume') return `outline.volume:single:${request.volumeId}`
+  return `outline.chapter:single:${request.chapterId}`
+}
+
+function decodeGenerationOperation(operation: string | null): OutlineGenerationRequest | null {
+  if (!operation) return null
+  if (operation === 'outline.volume' || operation === 'outline.volume:batch') return { kind: 'volumes' }
+  const parts = operation.split(':')
+  const id = Number(parts[2])
+  if (!Number.isFinite(id)) return null
+  if (parts[0] === 'outline.volume' && parts[1] === 'single') return { kind: 'single-volume', volumeId: id }
+  if (parts[0] === 'outline.chapter' && parts[1] === 'batch') return { kind: 'chapters', volumeId: id }
+  if (parts[0] === 'outline.chapter' && parts[1] === 'single') return { kind: 'single-chapter', chapterId: id }
+  return null
 }
 
 export default function OutlinePanel({ project, onOpenChapter }: Props) {
@@ -45,20 +135,71 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
   const [parameterValues, setParameterValues] = useState<Record<string, unknown>>({})
   const [systemOverride, setSystemOverride] = useState<string | null>(null)
   const [userOverride, setUserOverride] = useState<string | null>(null)
+  const [activeModuleKey, setActiveModuleKey] = useState<'outline.volume' | 'outline.chapter'>('outline.volume')
+  const [pendingGeneration, setPendingGeneration] = useState<OutlineGenerationRequest | null>(null)
   const [promptPanelOpen, setPromptPanelOpen] = useState(false)
-  const { activeChapterDrag, beginChapterDrag, clearActiveChapterDrag, getActiveChapterDrag } = useOutlineChapterDrag()
+  const [activeChapterDrag, setActiveChapterDrag] = useState<ChapterDragPayload | null>(null)
+  const [chapterDropTargetId, setChapterDropTargetId] = useState<number | null>(null)
+  const activeChapterDragRef = useRef<ChapterDragPayload | null>(null)
+
+  // ── 多选删除：卷 ──
+  const [volumeMultiSelect, setVolumeMultiSelect] = useState(false)
+  const [selectedVolumeIds, setSelectedVolumeIds] = useState<Set<number>>(new Set())
+
+  // ── 多选删除：章节（覆盖直挂章节 + 故事块内章节） ──
+  const [chapterMultiSelect, setChapterMultiSelect] = useState(false)
+  const [selectedChapterIds, setSelectedChapterIds] = useState<Set<number>>(new Set())
+
+  const beginChapterDrag = useCallback((payload: ChapterDragPayload) => {
+    activeChapterDragRef.current = payload
+    setActiveChapterDrag(payload)
+  }, [])
+
+  const clearActiveChapterDrag = useCallback(() => {
+    activeChapterDragRef.current = null
+    setActiveChapterDrag(null)
+    setChapterDropTargetId(null)
+  }, [])
+
+  const getActiveChapterDrag = useCallback(() => activeChapterDragRef.current, [])
 
   // 采纳预览
   const [previewVolumes, setPreviewVolumes] = useState<ParsedVolume[] | null>(null)
   const [previewChapters, setPreviewChapters] = useState<ParsedChapter[] | null>(null)
   const [previewTargetId, setPreviewTargetId] = useState<number | null>(null)
-  const clearGenerationPreview = useCallback(() => {
-    setPreviewVolumes(null)
-    setPreviewChapters(null)
-    setPreviewTargetId(null)
-  }, [])
+
+  // D1: 批量生成状态
+  const [batchProgress, setBatchProgress] = useState<BatchOutlineProgress | null>(null)
+  const [batchRunning, setBatchRunning] = useState(false)
+  const batchAbortRef = useRef<AbortController | null>(null)
+
+  const addOutlineNodeByAdopt = useCallback(async (node: {
+    parentId: number | null
+    type: 'volume' | 'chapter'
+    title: string
+    summary: string
+    order: number
+  }): Promise<{ id: number | null; reason?: string }> => {
+    // FB-10 修复:返回 skip 原因,供调用方反馈(此前 adopt 命中去重/必填/FK 失败时
+    // 进 skipped 静默不写、不报错,导致"点采纳却没写入也没提示")
+    const result = await adopt({
+      projectId: project.id!,
+      target: 'outlineNodes',
+      mode: 'add',
+      data: node,
+    })
+    const id = result.written[0]?.id ?? null
+    return { id, reason: id == null ? (result.skipped[0]?.reason ?? '未知原因') : undefined }
+  }, [project.id])
+  const [batchResult, setBatchResult] = useState<Map<number, ParsedChapter[]> | null>(null)
 
   const ai = useAIStream(createAISessionKey(project.id!, 'outline.generate'))
+  const sessionModuleKey: 'outline.volume' | 'outline.chapter' =
+    pendingGeneration
+      ? (pendingGeneration.kind === 'volumes' || pendingGeneration.kind === 'single-volume' ? 'outline.volume' : 'outline.chapter')
+      : ai.operation?.startsWith('outline.chapter') ? 'outline.chapter'
+      : ai.operation?.startsWith('outline.volume') ? 'outline.volume'
+        : activeModuleKey
 
   useEffect(() => { loadAll(project.id!) }, [project.id, loadAll])
 
@@ -66,14 +207,47 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
   const volumes = getTopLevelVolumes(normalizedNodes)
   const selectedVol = volumes.find(v => v.id === selectedVolId) || null
 
-  useOutlineChapterCountEstimate({
-    selectedVolumeId: selectedVolId,
-    selectedVolumeExists: selectedVol != null,
-    targetWordCount: project.targetWordCount,
-    volumeCount: volumes.length,
-    parameterValues,
-    setParameterValues,
-  })
+  // 修复「长卷被压成 ~20 章」：选中卷 / 改「每章字数」时，按「卷字数 ÷ 每章字数」自动估算
+  // 「本卷章节数」的智能默认值。用 ref 记住上次的估算值以区分：
+  //  · 当前章节数 == 上次估算值（用户没手动改）→ 用新估算覆盖（改每章字数能联动重算）；
+  //  · 当前章节数 ≠ 上次估算值（用户手动滑/填过）→ 保留用户值，绝不覆盖。
+  // 这样既有智能默认避坑，又完全尊重用户自定义。
+  const lastChapterEstimateRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (!selectedVol) return
+    const wpc = Number(parameterValues.wordsPerChapter) || DEFAULT_WORDS_PER_CHAPTER
+    const est = estimateChaptersPerVolume(project.targetWordCount, volumes.length, wpc)
+    setParameterValues(prev => {
+      const cur = prev.chaptersPerVolume
+      const untouched = cur == null || cur === '' || cur === lastChapterEstimateRef.current
+      if (!untouched) return prev
+      lastChapterEstimateRef.current = est
+      return { ...prev, chaptersPerVolume: est }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedVolId, parameterValues.wordsPerChapter])
+
+  // 故事块和章节层级
+  const selectedVolBlocks = useMemo(() => {
+    if (!selectedVol) return []
+    return normalizedNodes.filter(n => n.parentId === selectedVol.id && n.type === 'storyBlock').sort((a, b) => a.order - b.order)
+  }, [normalizedNodes, selectedVol])
+
+  // 直接挂在卷下的章节（无故事块归属）
+  const selectedVolChapters = useMemo(() => {
+    if (!selectedVol) return []
+    return normalizedNodes.filter(n => n.parentId === selectedVol.id && n.type === 'chapter').sort((a, b) => a.order - b.order)
+  }, [normalizedNodes, selectedVol])
+
+  // 是否使用故事块模式
+  const hasBlocks = selectedVolBlocks.length > 0
+
+  // FB-2 拖动排序：卷列表（侧栏）、直挂章节列表各一套
+  const volumeDnD = useDragReorder(volumes.map(v => v.id), (ids) => reorderNodes(ids))
+  const directChaptersDnD = useDragReorder(
+    selectedVolChapters.map(c => c.id),
+    (ids) => reorderNodes(ids),
+  )
 
   // 自动选中第一个卷
   useEffect(() => {
@@ -149,31 +323,28 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
   const handleAddStructure = async (structure: StoryStructure) => {
     if (!selectedVol) return
     const def = STORY_STRUCTURES[structure]
-    const currentBlocks = normalizedNodes
-      .filter(node => node.parentId === selectedVol.id && node.type === 'storyBlock')
-      .sort((a, b) => a.order - b.order)
     if (structure === 'custom') {
       await addNode({
         projectId: project.id!, parentId: selectedVol.id!, type: 'storyBlock',
-        title: '自定义故事块', summary: '', order: currentBlocks.length,
+        title: '自定义故事块', summary: '', order: selectedVolBlocks.length,
       })
     } else {
       for (let i = 0; i < def.blocks.length; i++) {
         await addNode({
           projectId: project.id!, parentId: selectedVol.id!, type: 'storyBlock',
-          title: def.blocks[i], summary: '', order: currentBlocks.length + i,
+          title: def.blocks[i], summary: '', order: selectedVolBlocks.length + i,
         })
       }
     }
   }
 
-  const generationRunOptions = useMemo(() => ({
+  const buildOpts = () => ({
     parameterValues: Object.keys(parameterValues).length > 0 ? parameterValues : undefined,
     overrides: (systemOverride != null || userOverride != null) ? {
       systemPrompt: systemOverride ?? undefined,
       userPromptTemplate: userOverride ?? undefined,
     } : undefined,
-  }), [parameterValues, systemOverride, userOverride])
+  })
 
   const buildOutlineAssembledContext = useCallback(async (worldGroupId: number | null, outlineNodeId?: number | null) => {
     return await assembleContext({
@@ -192,31 +363,236 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
         'worldRules',
         'historical',
         'locations',
-        'foreshadows',
         'existingVolumeOutlines',
         'writtenChapterProgress',
       ],
     })
   }, [project.id, aiConfig.provider, aiConfig.model])
 
-  const generation = useOutlineGenerationController({
-    project,
-    nodes,
-    volumes,
-    hint,
-    runOptions: generationRunOptions,
-    ai,
-    assembleContext: buildOutlineAssembledContext,
-    openPromptPanel: () => setPromptPanelOpen(true),
-    clearPreview: clearGenerationPreview,
-    onInfo: toast.info,
-    onError: toast.error,
-  })
-
-  const handleAIVolumes = () => { void generation.prepare({ kind: 'volumes' }) }
-  const handleAIChapters = () => {
-    if (selectedVol?.id) void generation.prepare({ kind: 'chapters', volumeId: selectedVol.id })
+  const contextPart = (assembled: AssembleContextResult, key: string): string => {
+    const idx = assembled.included.indexOf(key)
+    return idx >= 0 ? assembled.segments[idx]?.content ?? '' : ''
   }
+
+  // ── AI 生成 ──
+
+  const prepareGeneration = (request: OutlineGenerationRequest) => {
+    const moduleKey = request.kind === 'volumes' || request.kind === 'single-volume'
+      ? 'outline.volume'
+      : 'outline.chapter'
+    setActiveModuleKey(moduleKey)
+    setPendingGeneration(request)
+    setPromptPanelOpen(true)
+    setPreviewVolumes(null)
+    setPreviewChapters(null)
+    setPreviewTargetId(null)
+  }
+
+  const findVolumeForChapter = (chapterId: number) => {
+    const chapter = nodes.find(node => node.id === chapterId && node.type === 'chapter')
+    if (!chapter) return null
+    const parent = nodes.find(node => node.id === chapter.parentId)
+    if (parent?.type === 'volume') return parent
+    if (parent?.type === 'storyBlock') {
+      return nodes.find(node => node.id === parent.parentId && node.type === 'volume') ?? null
+    }
+    return null
+  }
+
+  const executeGeneration = async (request: OutlineGenerationRequest) => {
+    const moduleKey = request.kind === 'volumes' || request.kind === 'single-volume'
+      ? 'outline.volume'
+      : 'outline.chapter'
+    setActiveModuleKey(moduleKey)
+    ai.setOperation(encodeGenerationOperation(request))
+    setPreviewVolumes(null)
+    setPreviewChapters(null)
+    setPreviewTargetId(null)
+
+    if (request.kind === 'volumes' || request.kind === 'single-volume') {
+      const explicitCount = Number(parameterValues.volumeCount)
+      if (
+        request.kind === 'volumes' &&
+        parameterValues.volumeCount !== '' &&
+        parameterValues.volumeCount != null &&
+        Number.isFinite(explicitCount) &&
+        explicitCount > 0 &&
+        explicitCount <= volumes.length
+      ) {
+        ai.reset()
+        toast.info(`当前已有 ${volumes.length} 卷，已达到你设定的 ${Math.floor(explicitCount)} 卷，无需继续生成。`)
+        return
+      }
+      const targetVolume = request.kind === 'single-volume'
+        ? volumes.find(volume => volume.id === request.volumeId)
+        : null
+      if (request.kind === 'single-volume' && !targetVolume) {
+        toast.error('要补全的卷不存在，请重新选择。')
+        return
+      }
+      const assembled = await buildOutlineAssembledContext(targetVolume?.worldGroupId ?? null, targetVolume?.id)
+      const messages = buildVolumeOutlinePrompt(
+        project.name,
+        project.genre,
+        assembled.text,
+        contextPart(assembled, 'storyCore'),
+        project.targetWordCount || 500000,
+        hint,
+        buildOpts(),
+        contextPart(assembled, 'characters'),
+        contextPart(assembled, 'worldRules'),
+        {
+          existingVolumesContext: contextPart(assembled, 'existingVolumeOutlines'),
+          existingVolumeCount: volumes.length,
+          targetVolumeTitle: targetVolume?.title,
+        },
+      )
+      await ai.start(messages, undefined, { category: 'outline.volume', projectId: project.id! })
+      return
+    }
+
+    const volume = request.kind === 'chapters'
+      ? volumes.find(item => item.id === request.volumeId)
+      : findVolumeForChapter(request.chapterId)
+    if (!volume) {
+      toast.error('要生成章纲的卷不存在，请重新选择。')
+      return
+    }
+    const assembled = await buildOutlineAssembledContext(volume.worldGroupId ?? null, volume.id)
+    const volIdx = volumes.indexOf(volume)
+    const prevSummary = volIdx > 0 ? volumes[volIdx - 1].summary : ''
+    const charCtx = contextPart(assembled, 'characters')
+    const rulesCtx = contextPart(assembled, 'worldRules')
+    const messages = request.kind === 'single-chapter'
+      ? (() => {
+        const chapter = nodes.find(node => node.id === request.chapterId && node.type === 'chapter')!
+        const siblings = nodes
+          .filter(node => node.type === 'chapter' && node.parentId === chapter.parentId && node.id !== chapter.id)
+          .sort((a, b) => a.order - b.order)
+        const siblingContext = siblings.length
+          ? `同级已有章节：\n${siblings.map(item => `- ${item.title}${item.summary ? `：${item.summary}` : ''}`).join('\n')}`
+          : ''
+        return buildSingleChapterOutlinePrompt(
+          volume.title,
+          volume.summary,
+          chapter.title,
+          siblingContext,
+          assembled.text,
+          prevSummary,
+          hint,
+          buildOpts(),
+          charCtx,
+          rulesCtx,
+        )
+      })()
+      : buildChapterOutlinePrompt(
+        volume.title,
+        volume.summary,
+        assembled.text,
+        prevSummary,
+        hint,
+        buildOpts(),
+        charCtx,
+        rulesCtx,
+      )
+    await ai.start(messages, undefined, { category: 'outline.chapter', projectId: project.id! })
+  }
+
+  const handleAIVolumes = () => prepareGeneration({ kind: 'volumes' })
+  const handleAIChapters = () => {
+    if (selectedVol?.id) prepareGeneration({ kind: 'chapters', volumeId: selectedVol.id })
+  }
+  const handleConfirmGeneration = () => {
+    if (!pendingGeneration) return
+    const request = pendingGeneration
+    setPendingGeneration(null)
+    void executeGeneration(request)
+  }
+  const handleRetryGeneration = () => {
+    const request = decodeGenerationOperation(ai.operation)
+    if (request) void executeGeneration(request)
+  }
+
+  // ── D1: 批量生成 ──
+
+  const handleBatchGenerate = useCallback(async () => {
+    if (volumes.length === 0) return
+    setBatchRunning(true)
+    setBatchResult(null)
+    setBatchProgress(null)
+
+    const controller = new AbortController()
+    batchAbortRef.current = controller
+
+    const assembled = await buildOutlineAssembledContext(null)
+    const worldCtx = assembled.text
+    const charCtx = contextPart(assembled, 'characters')
+    const rulesCtx = contextPart(assembled, 'worldRules')
+
+    try {
+      const result = await runBatchOutlineGeneration({
+        volumes,
+        worldContext: worldCtx,
+        // 多世界：逐卷用本卷所属世界的上下文
+        worldContextResolver: project.enableMultiWorld
+          ? async (volId) => {
+            const vol = nodes.find(n => n.id === volId)
+            const resolved = await buildOutlineAssembledContext(vol?.worldGroupId ?? null, volId)
+            return resolved.text
+          }
+          : undefined,
+        worldRulesContextResolver: project.enableMultiWorld
+          ? async (volId) => {
+            const vol = nodes.find(n => n.id === volId)
+            const resolved = await buildOutlineAssembledContext(vol?.worldGroupId ?? null, volId)
+            return contextPart(resolved, 'worldRules')
+          }
+          : undefined,
+        userHint: hint || undefined,
+        characterContext: charCtx,
+        worldRulesContext: rulesCtx,
+        signal: controller.signal,
+        onProgress: setBatchProgress,
+      })
+      if (!result.cancelled) {
+        setBatchResult(result.chaptersByVolume)
+      }
+    } catch (err) {
+      console.error('[BatchOutline] 失败:', err)
+    } finally {
+      setBatchRunning(false)
+      batchAbortRef.current = null
+    }
+  }, [volumes, nodes, project.enableMultiWorld, hint, buildOutlineAssembledContext])
+
+  const handleBatchCancel = useCallback(() => {
+    batchAbortRef.current?.abort()
+    batchAbortRef.current = null
+    setBatchRunning(false)
+  }, [])
+
+  const handleBatchConfirm = useCallback(async () => {
+    if (!batchResult) return
+    try {
+      for (const [volId, chapters] of batchResult) {
+        const existingCount = nodes.filter(n => n.parentId === volId && n.type === 'chapter').length
+        for (let i = 0; i < chapters.length; i++) {
+          await addOutlineNodeByAdopt({
+            parentId: volId, type: 'chapter',
+            title: chapters[i].title, summary: chapters[i].summary,
+            order: existingCount + i,
+          })
+        }
+      }
+    } catch (err) {
+      console.error('[Outline] 批量写入章节失败:', err)
+      toast.error(`批量写入章节时出错：${err instanceof Error ? err.message : '未知错误'}。请查看控制台获取详情。`)
+      return
+    }
+    await loadAll(project.id!)
+    setBatchResult(null)
+    setBatchProgress(null)
+  }, [batchResult, nodes, addOutlineNodeByAdopt, loadAll, project.id])
 
   // ── 采纳预览 + 确认 ──
 
@@ -224,7 +600,7 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
   const handlePreviewAccept = async (text: string) => {
     setRestructuring(true)
     try {
-      if (generation.moduleKey === 'outline.volume') {
+      if (sessionModuleKey === 'outline.volume') {
         const parsed = await parseVolumeOutlineSmart(text, aiConfig)
         if (parsed.length === 0) {
           toast.error('未能从 AI 输出中解析出卷级大纲，请检查输出内容或重试。')
@@ -263,9 +639,15 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     const targetId = previewTargetId
     ai.reset()
     if (targetId != null) {
-      const result = await adoptGeneratedOutlineSummary(project.id!, targetId, previewVolumes[0]?.summary ?? '')
-      if (!result.written) {
-        toast.error(`未能写入本卷卷纲：${result.reason}`)
+      const result = await adopt({
+        projectId: project.id!,
+        target: 'outlineNodes',
+        recordId: targetId,
+        mode: 'replace',
+        data: { summary: previewVolumes[0]?.summary ?? '' },
+      })
+      if (result.written.length === 0) {
+        toast.error(`未能写入本卷卷纲：${result.skipped[0]?.reason ?? '结果为空'}`)
         return
       }
       await loadAll(project.id!)
@@ -275,15 +657,19 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
       return
     }
     const existingCount = volumes.length
-    let result: Awaited<ReturnType<typeof adoptGeneratedOutlineItems>>
+    let firstId: number | null = null
+    let written = 0
+    const skipReasons = new Set<string>()
     try {
-      result = await adoptGeneratedOutlineItems({
-        projectId: project.id!,
-        parentId: null,
-        type: 'volume',
-        items: previewVolumes,
-        startingOrder: existingCount,
-      })
+      for (let i = 0; i < previewVolumes.length; i++) {
+        const r = await addOutlineNodeByAdopt({
+          parentId: null, type: 'volume',
+          title: previewVolumes[i].title, summary: previewVolumes[i].summary,
+          order: existingCount + i,
+        })
+        if (r.id != null) { written++; if (firstId == null) firstId = r.id }
+        else if (r.reason) skipReasons.add(r.reason)
+      }
     } catch (err) {
       console.error('[Outline] 写入卷失败:', err)
       toast.error(`写入卷时出错：${err instanceof Error ? err.message : '未知错误'}。请查看控制台获取详情。`)
@@ -292,14 +678,14 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     await loadAll(project.id!)
     setPreviewVolumes(null)
     setPreviewTargetId(null)
-    if (result.firstId) setSelectedVolId(result.firstId)
+    if (firstId) setSelectedVolId(firstId)
     // FB-10:不再静默——全跳过/部分跳过都明确告知用户原因
-    if (result.writtenCount === 0) {
-      toast.error(`未写入任何卷。原因:${result.skippedReasons.join('；') || '与已有卷标题重复(已跳过)'}。若想替换/更新同名卷,请先删除同名卷再采纳。`)
-    } else if (result.writtenCount < previewVolumes.length) {
-      toast.info(`已写入 ${result.writtenCount} 个卷,另有 ${previewVolumes.length - result.writtenCount} 个被跳过(${result.skippedReasons.join('；') || '标题重复'})。`)
+    if (written === 0) {
+      toast.error(`未写入任何卷。原因:${[...skipReasons].join('；') || '与已有卷标题重复(已跳过)'}。若想替换/更新同名卷,请先删除同名卷再采纳。`)
+    } else if (written < previewVolumes.length) {
+      toast.info(`已写入 ${written} 个卷,另有 ${previewVolumes.length - written} 个被跳过(${[...skipReasons].join('；') || '标题重复'})。`)
     } else {
-      toast.success(`已写入 ${result.writtenCount} 个卷。`)
+      toast.success(`已写入 ${written} 个卷。`)
     }
   }
 
@@ -309,9 +695,15 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     const operation = decodeGenerationOperation(ai.operation)
     ai.reset()
     if (targetId != null) {
-      const result = await adoptGeneratedOutlineSummary(project.id!, targetId, previewChapters[0]?.summary ?? '')
-      if (!result.written) {
-        toast.error(`未能写入本章章纲：${result.reason}`)
+      const result = await adopt({
+        projectId: project.id!,
+        target: 'outlineNodes',
+        recordId: targetId,
+        mode: 'replace',
+        data: { summary: previewChapters[0]?.summary ?? '' },
+      })
+      if (result.written.length === 0) {
+        toast.error(`未能写入本章章纲：${result.skipped[0]?.reason ?? '结果为空'}`)
         return
       }
       await loadAll(project.id!)
@@ -325,15 +717,18 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
       : selectedVol
     if (!destinationVolume) return
     const existingCount = nodes.filter(node => node.parentId === destinationVolume.id && node.type === 'chapter').length
-    let result: Awaited<ReturnType<typeof adoptGeneratedOutlineItems>>
+    let written = 0
+    const skipReasons = new Set<string>()
     try {
-      result = await adoptGeneratedOutlineItems({
-        projectId: project.id!,
-        parentId: destinationVolume.id!,
-        type: 'chapter',
-        items: previewChapters,
-        startingOrder: existingCount,
-      })
+      for (let i = 0; i < previewChapters.length; i++) {
+        const r = await addOutlineNodeByAdopt({
+          parentId: destinationVolume.id!, type: 'chapter',
+          title: previewChapters[i].title, summary: previewChapters[i].summary,
+          order: existingCount + i,
+        })
+        if (r.id != null) written++
+        else if (r.reason) skipReasons.add(r.reason)
+      }
     } catch (err) {
       console.error('[Outline] 写入章节失败:', err)
       toast.error(`写入章节时出错：${err instanceof Error ? err.message : '未知错误'}。请查看控制台获取详情。`)
@@ -342,10 +737,10 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     await loadAll(project.id!)
     setPreviewChapters(null)
     setPreviewTargetId(null)
-    if (result.writtenCount === 0) {
-      toast.error(`未写入任何章节。原因:${result.skippedReasons.join('；') || '与本卷已有章节标题重复(已跳过)'}。`)
-    } else if (result.writtenCount < previewChapters.length) {
-      toast.info(`已写入 ${result.writtenCount} 章,另有 ${previewChapters.length - result.writtenCount} 章被跳过(${result.skippedReasons.join('；') || '标题重复'})。`)
+    if (written === 0) {
+      toast.error(`未写入任何章节。原因:${[...skipReasons].join('；') || '与本卷已有章节标题重复(已跳过)'}。`)
+    } else if (written < previewChapters.length) {
+      toast.info(`已写入 ${written} 章,另有 ${previewChapters.length - written} 章被跳过(${[...skipReasons].join('；') || '标题重复'})。`)
     }
   }
 
@@ -362,43 +757,338 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
     setSelectedVolId(null)
   }
 
-  const batch = useOutlineBatchGeneration({
-    projectId: project.id!,
-    multiWorldEnabled: Boolean(project.enableMultiWorld),
-    volumes,
-    nodes,
-    hint,
-    assembleContext: buildOutlineAssembledContext,
-    reloadOutline: () => loadAll(project.id!),
-    onError: toast.error,
-  })
+  // ── 多选删除：卷 ──
+
+  const toggleVolumeSelect = (volId: number) => {
+    setSelectedVolumeIds(prev => {
+      const next = new Set(prev)
+      if (next.has(volId)) next.delete(volId)
+      else next.add(volId)
+      return next
+    })
+  }
+
+  const toggleVolumeSelectAll = () => {
+    setSelectedVolumeIds(prev => {
+      if (prev.size === volumes.length) return new Set()
+      return new Set(volumes.map(v => v.id!))
+    })
+  }
+
+  const handleEnterVolumeMultiSelect = () => {
+    setVolumeMultiSelect(true)
+    setSelectedVolumeIds(new Set())
+  }
+
+  const handleExitVolumeMultiSelect = () => {
+    setVolumeMultiSelect(false)
+    setSelectedVolumeIds(new Set())
+  }
+
+  const handleBatchDeleteVolumes = async () => {
+    if (selectedVolumeIds.size === 0) return
+    const ok = await dialog.confirm({
+      title: `删除选中的 ${selectedVolumeIds.size} 个卷？`,
+      message: '这些卷连同其下所有章节和故事块都会被删除，此操作不可恢复。',
+      confirmText: '删除',
+      tone: 'danger',
+    })
+    if (!ok) return
+    const ids = Array.from(selectedVolumeIds)
+    for (const id of ids) {
+      deleteNode(id)
+    }
+    if (selectedVolId != null && selectedVolumeIds.has(selectedVolId)) {
+      setSelectedVolId(null)
+    }
+    setSelectedVolumeIds(new Set())
+    setVolumeMultiSelect(false)
+    toast.success(`已删除 ${ids.length} 个卷。`)
+  }
+
+  // ── 多选删除：章节 ──
+
+  const toggleChapterSelect = (chapterId: number) => {
+    setSelectedChapterIds(prev => {
+      const next = new Set(prev)
+      if (next.has(chapterId)) next.delete(chapterId)
+      else next.add(chapterId)
+      return next
+    })
+  }
+
+  const handleEnterChapterMultiSelect = () => {
+    setChapterMultiSelect(true)
+    setSelectedChapterIds(new Set())
+  }
+
+  const handleExitChapterMultiSelect = () => {
+    setChapterMultiSelect(false)
+    setSelectedChapterIds(new Set())
+  }
+
+  // 「全选当前可见章节」——包括直挂章节 + 所有故事块内章节
+  const visibleChapterIds = useMemo(() => {
+    if (!selectedVol) return [] as number[]
+    const direct = selectedVolChapters.map(c => c.id!)
+    const inBlocks = selectedVolBlocks.flatMap(b =>
+      normalizedNodes
+        .filter(n => n.parentId === b.id && n.type === 'chapter')
+        .map(n => n.id!),
+    )
+    return [...direct, ...inBlocks]
+  }, [selectedVol, selectedVolChapters, selectedVolBlocks, normalizedNodes])
+
+  const toggleChapterSelectAll = () => {
+    setSelectedChapterIds(prev => {
+      if (prev.size === visibleChapterIds.length && visibleChapterIds.length > 0) return new Set()
+      return new Set(visibleChapterIds)
+    })
+  }
+
+  const handleBatchDeleteChapters = async () => {
+    if (selectedChapterIds.size === 0) return
+    const ok = await dialog.confirm({
+      title: `删除选中的 ${selectedChapterIds.size} 个章节？`,
+      message: '这些章节将被一次性删除，此操作不可恢复。',
+      confirmText: '删除',
+      tone: 'danger',
+    })
+    if (!ok) return
+    const ids = Array.from(selectedChapterIds)
+    for (const id of ids) {
+      deleteNode(id)
+    }
+    setSelectedChapterIds(new Set())
+    setChapterMultiSelect(false)
+    toast.success(`已删除 ${ids.length} 个章节。`)
+  }
+
+  const handleCancelPreview = () => {
+    setPreviewVolumes(null)
+    setPreviewChapters(null)
+    setPreviewTargetId(null)
+  }
 
   // ── 侧栏：卷列表 ──
 
   const sidebarContent = (
-    <OutlineVolumeSidebar
-      volumes={volumes}
-      nodes={normalizedNodes}
-      selectedVolumeId={selectedVolId}
-      multiWorldEnabled={Boolean(project.enableMultiWorld)}
-      worldGroups={worldGroups}
-      aiStreaming={ai.isStreaming}
-      batchRunning={batch.running}
-      batchProgress={batch.progress}
-      batchResult={batch.result}
-      activeChapterDrag={activeChapterDrag}
-      getActiveChapterDrag={getActiveChapterDrag}
-      onClearActiveChapterDrag={clearActiveChapterDrag}
-      onSelectVolume={setSelectedVolId}
-      onAddVolume={() => { void handleAddVolume() }}
-      onGenerateVolumes={handleAIVolumes}
-      onGenerateAllChapters={() => { void batch.generate() }}
-      onCancelBatch={batch.cancel}
-      onConfirmBatch={() => { void batch.confirm() }}
-      onDismissBatch={batch.dismiss}
-      onReorderVolumes={reorderNodes}
-      onMoveChapter={handleMoveChapter}
-    />
+    <div className="flex flex-col h-full">
+      {/* 操作栏 */}
+      <div className="p-2 space-y-1.5">
+        {!volumeMultiSelect ? (
+          <button onClick={handleEnterVolumeMultiSelect} disabled={volumes.length === 0}
+            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-bg-elevated text-text-secondary rounded-md hover:text-error border border-border disabled:opacity-40 transition-colors">
+            <CheckSquare className="w-3.5 h-3.5" /> 多选删除
+          </button>
+        ) : (
+          <button onClick={handleExitVolumeMultiSelect}
+            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-bg-elevated text-text-secondary rounded-md hover:text-text-primary border border-border transition-colors">
+            <X className="w-3.5 h-3.5" /> 退出多选
+          </button>
+        )}
+        <button onClick={handleAddVolume} disabled={volumeMultiSelect}
+          className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-bg-elevated text-text-secondary rounded-md hover:text-text-primary border border-border disabled:opacity-40 transition-colors">
+          <Plus className="w-3.5 h-3.5" /> 添加卷
+        </button>
+        <button onClick={handleAIVolumes} disabled={ai.isStreaming || batchRunning || volumeMultiSelect}
+          className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-accent text-white rounded-md hover:bg-accent-hover disabled:opacity-50 transition-colors">
+          <Sparkles className="w-3.5 h-3.5" /> 批量生成卷级大纲
+        </button>
+        {volumes.length >= 2 && (
+          <button onClick={handleBatchGenerate} disabled={ai.isStreaming || batchRunning || volumeMultiSelect}
+            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-bg-elevated text-accent rounded-md hover:bg-accent/10 border border-accent/30 disabled:opacity-50 transition-colors">
+            <Layers className="w-3.5 h-3.5" /> 批量生成所有卷的章节
+          </button>
+        )}
+      </div>
+
+      {/* 多选模式：操作栏 */}
+      {volumeMultiSelect && (
+        <div className="px-2 pb-2 space-y-1.5">
+          <button
+            onClick={toggleVolumeSelectAll}
+            disabled={volumes.length === 0}
+            className="w-full flex items-center justify-between gap-1.5 px-2 py-1.5 text-xs bg-bg-surface border border-border rounded-md hover:border-accent/50 disabled:opacity-40 transition-colors"
+          >
+            <span className="flex items-center gap-1.5">
+              {selectedVolumeIds.size === volumes.length && volumes.length > 0
+                ? <CheckSquare className="w-3.5 h-3.5 text-accent" />
+                : <Square className="w-3.5 h-3.5 text-text-muted" />}
+              {selectedVolumeIds.size === volumes.length && volumes.length > 0 ? '取消全选' : '全选'}
+            </span>
+            <span className="text-text-muted">已选 {selectedVolumeIds.size}/{volumes.length}</span>
+          </button>
+          <button
+            onClick={handleBatchDeleteVolumes}
+            disabled={selectedVolumeIds.size === 0}
+            className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-error/10 text-error border border-error/40 rounded-md hover:bg-error/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <Trash2 className="w-3.5 h-3.5" /> 删除选中 ({selectedVolumeIds.size})
+          </button>
+        </div>
+      )}
+
+      {/* 批量生成进度 */}
+      {(batchRunning || batchResult) && (
+        <div className="px-2 pb-2">
+          <div className="bg-bg-surface border border-border rounded-lg p-2 space-y-1.5">
+            {batchRunning && batchProgress && (
+              <>
+                <div className="flex items-center gap-1.5 text-xs text-accent">
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                  <span>{batchProgress.completedVolumes}/{batchProgress.totalVolumes} 卷</span>
+                </div>
+                <div className="w-full bg-border rounded-full h-1.5">
+                  <div
+                    className="bg-accent h-1.5 rounded-full transition-all"
+                    style={{ width: `${(batchProgress.completedVolumes / batchProgress.totalVolumes) * 100}%` }}
+                  />
+                </div>
+                <p className="text-[10px] text-text-muted truncate">{batchProgress.stage}</p>
+                <button onClick={handleBatchCancel}
+                  className="w-full px-2 py-1 text-[10px] text-error border border-error/30 rounded hover:bg-error/10 transition-colors">
+                  取消
+                </button>
+              </>
+            )}
+            {!batchRunning && batchResult && (
+              <>
+                <p className="text-xs text-success">
+                  批量生成完成：{Array.from(batchResult.values()).reduce((s, chs) => s + chs.length, 0)} 章
+                </p>
+                <div className="flex gap-1">
+                  <button onClick={handleBatchConfirm}
+                    className="flex-1 flex items-center justify-center gap-1 px-2 py-1 text-[10px] bg-accent text-white rounded hover:bg-accent-hover transition-colors">
+                    <Check className="w-3 h-3" /> 全部写入
+                  </button>
+                  <button onClick={() => { setBatchResult(null); setBatchProgress(null) }}
+                    className="px-2 py-1 text-[10px] text-text-muted border border-border rounded hover:text-text-primary transition-colors">
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* 卷列表 */}
+      <div className="flex-1 overflow-y-auto px-1">
+        {volumes.map(vol => {
+          const blockIds = new Set(nodes.filter(n => n.parentId === vol.id && n.type === 'storyBlock').map(n => n.id))
+          const childCount = nodes.filter(n =>
+            n.type === 'chapter'
+            && (n.parentId === vol.id || blockIds.has(n.parentId ?? undefined)),
+          ).length
+          const active = selectedVolId === vol.id
+          const d = volumeDnD.itemDnD(vol.id)
+          const dropToVolumeProps = chapterDropProps({
+            targetParentId: vol.id!,
+            targetIndex: normalizedNodes.filter(n => n.parentId === vol.id && n.type === 'chapter').length,
+            onMoveChapter: handleMoveChapter,
+            getActiveChapterDrag,
+            clearActiveChapterDrag,
+          })
+          const isChapterDropTarget = chapterDropTargetId === vol.id && activeChapterDrag != null
+          const checked = vol.id != null && selectedVolumeIds.has(vol.id)
+          // 多选模式下：禁用拖拽 drop、点击卷名切换选中而非切显示
+          const dragDisabled = volumeMultiSelect
+          return (
+            <div
+              key={vol.id}
+              {...(dragDisabled ? {} : d.dropProps)}
+              data-outline-volume-id={vol.id}
+              data-chapter-drop-target={!dragDisabled && isChapterDropTarget ? 'true' : undefined}
+              onDragEnter={(event) => {
+                if (dragDisabled) return
+                d.dropProps.onDragEnter()
+                if (getActiveChapterDrag() || hasChapterDragPayload(event)) setChapterDropTargetId(vol.id!)
+              }}
+              onDragLeave={(event) => {
+                if (dragDisabled) return
+                d.dropProps.onDragLeave()
+                if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                  setChapterDropTargetId(current => current === vol.id ? null : current)
+                }
+              }}
+              onDragOver={(event) => {
+                if (dragDisabled) return
+                if (getActiveChapterDrag() || hasChapterDragPayload(event)) {
+                  setChapterDropTargetId(vol.id!)
+                  dropToVolumeProps.onDragOver(event)
+                  return
+                }
+                d.dropProps.onDragOver(event)
+              }}
+              onDrop={(event) => {
+                if (dragDisabled) return
+                if (getActiveChapterDrag() || hasChapterDragPayload(event)) {
+                  void dropToVolumeProps.onDrop(event)
+                  return
+                }
+                d.dropProps.onDrop(event)
+              }}
+              className={`group/vol flex items-center rounded-lg mb-0.5 transition-all ${
+                volumeMultiSelect
+                  ? checked
+                    ? 'bg-accent/10 border-l-2 border-accent'
+                    : 'hover:bg-bg-hover border-l-2 border-transparent'
+                  : active
+                    ? 'bg-accent/8 border-l-2 border-accent'
+                    : 'hover:bg-bg-hover border-l-2 border-transparent'
+              } ${d.isDragging ? 'opacity-40' : ''} ${d.isOver || isChapterDropTarget ? 'ring-1 ring-accent/60 bg-accent/10' : ''}`}
+            >
+              {/* 多选模式下显示复选框；非多选模式显示拖拽手柄 */}
+              {volumeMultiSelect ? (
+                <button
+                  onClick={() => vol.id != null && toggleVolumeSelect(vol.id)}
+                  className="shrink-0 pl-1.5 pr-1 py-2 text-text-muted hover:text-accent"
+                  title={checked ? '取消选中' : '选中'}
+                >
+                  {checked
+                    ? <CheckSquare className="w-4 h-4 text-accent" />
+                    : <Square className="w-4 h-4" />}
+                </button>
+              ) : (
+                <span
+                  {...d.dragHandleProps}
+                  title="拖动调整卷顺序"
+                  className="shrink-0 pl-1 pr-0.5 py-2 cursor-grab active:cursor-grabbing text-text-muted/40 group-hover/vol:text-text-muted"
+                >
+                  <GripVertical className="w-3.5 h-3.5" />
+                </span>
+              )}
+              <button
+                onClick={() => {
+                  if (volumeMultiSelect) {
+                    if (vol.id != null) toggleVolumeSelect(vol.id)
+                  } else {
+                    setSelectedVolId(vol.id!)
+                  }
+                }}
+                className="min-w-0 flex-1 text-left px-1 py-2"
+              >
+                <p className={`text-sm font-medium truncate ${volumeMultiSelect ? (checked ? 'text-accent' : 'text-text-primary') : (active ? 'text-accent' : 'text-text-primary')}`}>
+                  {project.enableMultiWorld && vol.worldGroupId != null && (
+                    <span className="mr-1">{worldGroups.find(g => g.id === vol.worldGroupId)?.icon || '🌐'}</span>
+                  )}
+                  {vol.title}
+                </p>
+                <p className="text-[10px] text-text-muted">
+                  {childCount} 章{vol.summary ? ` · ${vol.summary.slice(0, 20)}...` : ''}
+                </p>
+              </button>
+            </div>
+          )
+        })}
+        {volumes.length === 0 && (
+          <div className="text-center py-8 text-text-muted text-xs">
+            还没有卷
+          </div>
+        )}
+      </div>
+    </div>
   )
 
   // ── 右侧编辑区 ──
@@ -418,7 +1108,7 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
           className="w-full px-3 py-2 bg-bg-surface border border-border rounded-md text-text-primary text-sm focus:outline-none focus:border-accent" />
 
         <PromptRunPanel
-          moduleKey={generation.moduleKey}
+          moduleKey={sessionModuleKey}
           parameterValues={parameterValues}
           onParamChange={setParameterValues}
           systemOverride={systemOverride}
@@ -429,61 +1119,654 @@ export default function OutlinePanel({ project, onOpenChapter }: Props) {
           onOpenChange={setPromptPanelOpen}
         />
 
-        {generation.pendingRequest && (
-          <OutlineGenerationRequestPanel
-            request={generation.pendingRequest}
-            preparedContext={generation.preparedContext}
-            loading={generation.contextLoading}
-            error={generation.contextError}
-            onRetry={() => { void generation.prepare(generation.pendingRequest!) }}
-            onCancel={generation.cancel}
-            onConfirm={() => { void generation.confirm() }}
+        {pendingGeneration && (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-accent/30 bg-accent/5 px-3 py-2">
+            <div className="text-xs text-text-secondary">
+              <span className="font-medium text-text-primary">
+                {pendingGeneration.kind === 'volumes' && '批量生成卷级大纲'}
+                {pendingGeneration.kind === 'chapters' && '生成本卷所有章节'}
+                {pendingGeneration.kind === 'single-volume' && 'AI 生成本卷卷纲'}
+                {pendingGeneration.kind === 'single-chapter' && 'AI 生成本章章纲'}
+              </span>
+              <span className="ml-2">
+                {pendingGeneration.kind === 'single-chapter'
+                  ? '单章补全固定只生成当前 1 章；上方“本卷章节数”不参与本次调用。确认后才会调用 API。'
+                  : '请先调整上方参数，确认后才会调用 API。'}
+              </span>
+            </div>
+            <div className="flex shrink-0 gap-2">
+              <button
+                onClick={() => setPendingGeneration(null)}
+                className="px-2.5 py-1 text-xs text-text-muted border border-border rounded hover:text-text-primary"
+              >
+                取消
+              </button>
+              <button
+                onClick={handleConfirmGeneration}
+                className="px-2.5 py-1 text-xs text-white bg-accent rounded hover:bg-accent-hover"
+              >
+                确认生成
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* AI 输出（就地显示） */}
+        {(ai.output || ai.isStreaming || ai.error) && (
+          <AIStreamOutput output={ai.output} isStreaming={ai.isStreaming} error={ai.error} tokenUsage={ai.tokenUsage}
+            onStop={ai.stop}
+            onAccept={handlePreviewAccept}
+            onRetry={handleRetryGeneration}
+            moduleKey={sessionModuleKey} />
+        )}
+
+        {restructuring && (
+          <div className="flex items-center gap-2 text-xs text-accent">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" /> 正在用 AI 整理大纲结构…
+          </div>
+        )}
+
+        {/* 采纳预览：卷 */}
+        {previewVolumes && (
+          <PreviewPanel
+            label={previewTargetId != null ? '将补全当前卷的卷纲' : `将创建 ${previewVolumes.length} 个卷`}
+            items={previewVolumes}
+            onConfirm={handleConfirmVolumes}
+            onCancel={handleCancelPreview}
           />
         )}
 
-        <OutlineGenerationResultPanel
-          output={ai.output}
-          isStreaming={ai.isStreaming}
-          error={ai.error}
-          tokenUsage={ai.tokenUsage}
-          moduleKey={generation.moduleKey}
-          restructuring={restructuring}
-          previewVolumes={previewVolumes}
-          previewChapters={previewChapters}
-          previewTargetId={previewTargetId}
-          selectedVolumeTitle={selectedVol?.title}
-          onStop={ai.stop}
-          onAccept={handlePreviewAccept}
-          onRetry={() => { void generation.retry() }}
-          onConfirmVolumes={() => { void handleConfirmVolumes() }}
-          onConfirmChapters={() => { void handleConfirmChapters() }}
-          onCancelPreview={clearGenerationPreview}
-        />
+        {/* 采纳预览：章节 */}
+        {previewChapters && (
+          <PreviewPanel
+            label={previewTargetId != null
+              ? '将补全当前章节的章纲'
+              : `将在「${selectedVol?.title}」下创建 ${previewChapters.length} 个章节`}
+            items={previewChapters}
+            onConfirm={handleConfirmChapters}
+            onCancel={handleCancelPreview}
+          />
+        )}
 
-        <OutlineVolumeDetail
-          volume={selectedVol}
-          nodes={normalizedNodes}
-          multiWorldEnabled={Boolean(project.enableMultiWorld)}
-          worldGroups={worldGroups}
-          aiStreaming={ai.isStreaming}
-          activeChapterDrag={activeChapterDrag}
-          getActiveChapterDrag={getActiveChapterDrag}
-          onChapterDragStart={beginChapterDrag}
-          onChapterDragEnd={clearActiveChapterDrag}
-          onUpdateNode={updateNode}
-          onDeleteNode={deleteNode}
-          onGenerateVolume={volumeId => { void generation.prepare({ kind: 'single-volume', volumeId }) }}
-          onGenerateAllChapters={handleAIChapters}
-          onAddChapter={parentId => { void handleAddChapter(parentId) }}
-          onDeleteVolume={() => { void handleDeleteSelectedVolume() }}
-          onAddStructure={structure => { void handleAddStructure(structure) }}
-          onInsertChapterAfter={(chapterId, parentId) => { void handleInsertChapterAfter(chapterId, parentId) }}
-          onGenerateChapter={chapterId => { void generation.prepare({ kind: 'single-chapter', chapterId }) }}
-          onOpenChapter={onOpenChapter}
-          onReorderNodes={orderedIds => { void reorderNodes(orderedIds) }}
-          onMoveChapter={handleMoveChapter}
-        />
+        {/* ── 选中卷的详情编辑 ── */}
+        {selectedVol ? (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <CInput
+                value={selectedVol.title}
+                onChange={e => updateNode(selectedVol.id!, { title: e.target.value })}
+                className="text-lg font-bold bg-transparent text-text-primary outline-none flex-1"
+              />
+              <div className="flex items-center gap-1.5">
+                {!selectedVol.summary.trim() && (
+                  <button
+                    onClick={() => prepareGeneration({ kind: 'single-volume', volumeId: selectedVol.id! })}
+                    disabled={ai.isStreaming}
+                    className="flex items-center gap-1 px-2.5 py-1.5 text-xs bg-bg-elevated text-accent rounded-md hover:bg-accent/10 border border-accent/30 disabled:opacity-50 transition-colors"
+                  >
+                    <Sparkles className="w-3.5 h-3.5" /> AI 生成本卷卷纲
+                  </button>
+                )}
+                <button onClick={handleAIChapters} disabled={ai.isStreaming}
+                  className="flex items-center gap-1 px-2.5 py-1.5 text-xs bg-accent text-white rounded-md hover:bg-accent-hover disabled:opacity-50 transition-colors">
+                  <Sparkles className="w-3.5 h-3.5" /> 生成本卷所有章节
+                </button>
+                <button onClick={() => handleAddChapter()}
+                  className="flex items-center gap-1 px-2.5 py-1.5 text-xs bg-bg-elevated text-text-secondary rounded-md hover:text-text-primary border border-border transition-colors">
+                  <Plus className="w-3.5 h-3.5" /> 添加章节
+                </button>
+                <button onClick={() => { void handleDeleteSelectedVolume() }} className="p-1.5 text-text-muted hover:text-error rounded transition-colors">
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* 多世界：本卷所属世界 */}
+            {project.enableMultiWorld && worldGroups.length > 1 && (
+              <div className="flex items-center gap-2">
+                <label className="text-xs text-text-muted">本卷所属世界</label>
+                <select
+                  value={selectedVol.worldGroupId ?? ''}
+                  onChange={e => updateNode(selectedVol.id!, { worldGroupId: e.target.value ? Number(e.target.value) : null })}
+                  className="px-2 py-1 bg-bg-surface border border-border rounded text-xs text-text-primary focus:outline-none focus:border-accent cursor-pointer"
+                >
+                  <option value="">未指定</option>
+                  {worldGroups.map(g => (
+                    <option key={g.id} value={g.id}>{g.icon || '🌐'} {g.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* 卷摘要 */}
+            <div>
+              <label className="text-xs text-text-muted mb-1 block">卷情节摘要</label>
+              <AutoResizeTextarea
+                value={selectedVol.summary}
+                onChange={e => updateNode(selectedVol.id!, { summary: e.target.value })}
+                placeholder="描述本卷的核心冲突、关键转折和主要情节..."
+                minRows={3}
+                maxRows={10}
+                className="w-full px-3 py-2 bg-bg-surface border border-border rounded-md text-text-secondary text-sm focus:outline-none focus:border-accent"
+              />
+            </div>
+
+            {/* 故事结构 + 章节列表 */}
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-medium text-text-primary">
+                  {hasBlocks ? '故事结构' : '章节列表'}
+                  <span className="text-text-muted font-normal ml-1">（{selectedVolChapters.length + normalizedNodes.filter(n => selectedVolBlocks.some(b => b.id === n.parentId) && n.type === 'chapter').length} 章）</span>
+                </h3>
+                <div className="flex items-center gap-2">
+                  {visibleChapterIds.length > 0 && (
+                    !chapterMultiSelect ? (
+                      <button
+                        onClick={handleEnterChapterMultiSelect}
+                        className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-error border border-border rounded-md transition-colors"
+                        title="进入章节多选删除"
+                      >
+                        <CheckSquare className="w-3.5 h-3.5" /> 多选删除
+                      </button>
+                    ) : (
+                      <button
+                        onClick={handleExitChapterMultiSelect}
+                        className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-primary border border-border rounded-md transition-colors"
+                      >
+                        <X className="w-3.5 h-3.5" /> 退出多选
+                      </button>
+                    )
+                  )}
+                  {!hasBlocks && !chapterMultiSelect && (
+                    <StructureMenu onSelect={handleAddStructure} />
+                  )}
+                </div>
+              </div>
+
+              {/* 章节多选操作栏 */}
+              {chapterMultiSelect && (
+                <div className="flex items-center justify-between gap-2 mb-2 px-3 py-2 bg-bg-surface border border-border rounded-md">
+                  <button
+                    onClick={toggleChapterSelectAll}
+                    disabled={visibleChapterIds.length === 0}
+                    className="flex items-center gap-1.5 px-2 py-1 text-xs text-text-secondary hover:text-accent disabled:opacity-40"
+                  >
+                    {selectedChapterIds.size === visibleChapterIds.length && visibleChapterIds.length > 0
+                      ? <CheckSquare className="w-3.5 h-3.5 text-accent" />
+                      : <Square className="w-3.5 h-3.5 text-text-muted" />}
+                    {selectedChapterIds.size === visibleChapterIds.length && visibleChapterIds.length > 0 ? '取消全选' : '全选'}
+                  </button>
+                  <span className="text-xs text-text-muted">已选 {selectedChapterIds.size}/{visibleChapterIds.length}</span>
+                  <button
+                    onClick={handleBatchDeleteChapters}
+                    disabled={selectedChapterIds.size === 0}
+                    className="flex items-center gap-1 px-2 py-1 text-xs text-error bg-error/10 border border-error/40 rounded hover:bg-error/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" /> 删除选中 ({selectedChapterIds.size})
+                  </button>
+                </div>
+              )}
+
+              {/* 故事块模式 */}
+              {hasBlocks && (
+                <div className="space-y-3 mb-3">
+                  {selectedVolBlocks.map(block => {
+                    const blockChapters = normalizedNodes.filter(n => n.parentId === block.id && n.type === 'chapter').sort((a, b) => a.order - b.order)
+                    return (
+                      <StoryBlockSection
+                        key={block.id}
+                        block={block}
+                        chapters={blockChapters}
+                        onUpdateNode={updateNode}
+                        onDeleteNode={deleteNode}
+                        onAddChapter={() => handleAddChapter(block.id!)}
+                        onOpenChapter={onOpenChapter}
+                        onReorder={(ids) => reorderNodes(ids)}
+                        onInsertAfter={(chId) => handleInsertChapterAfter(chId, block.id!)}
+                        onGenerateChapter={(chapterId) => prepareGeneration({ kind: 'single-chapter', chapterId })}
+                        onMoveChapter={handleMoveChapter}
+                        activeChapterDrag={activeChapterDrag}
+                        getActiveChapterDrag={getActiveChapterDrag}
+                        onChapterDragStart={beginChapterDrag}
+                        onChapterDragEnd={clearActiveChapterDrag}
+                        chapterMultiSelect={chapterMultiSelect}
+                        selectedChapterIds={selectedChapterIds}
+                        onToggleChapterSelect={toggleChapterSelect}
+                      />
+                    )
+                  })}
+                  {!chapterMultiSelect && (
+                    <button onClick={() => handleAddStructure('custom')}
+                      className="w-full py-2 text-xs text-text-muted border border-dashed border-border rounded-lg hover:text-accent hover:border-accent/50 transition-colors">
+                      + 添加故事块
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {/* 无故事块：直接章节列表 */}
+              {!hasBlocks && (
+                selectedVolChapters.length === 0 ? (
+                  <div className="text-center py-8 text-text-muted text-sm border border-dashed border-border rounded-lg">
+                    还没有章节，点击「生成本卷所有章节」或「添加章节」
+                  </div>
+                ) : (
+                  <div className="space-y-1">
+                    {selectedVolChapters.map((ch, idx) => (
+                      <ChapterRow
+                        key={ch.id} ch={ch} idx={idx}
+                        onUpdate={updateNode} onDelete={deleteNode} onOpen={onOpenChapter}
+                        dnd={directChaptersDnD.itemDnD(ch.id)}
+                        onInsertAfter={() => handleInsertChapterAfter(ch.id!, selectedVol.id!)}
+                        onGenerate={() => prepareGeneration({ kind: 'single-chapter', chapterId: ch.id! })}
+                        parentId={selectedVol.id!}
+                        onMoveChapter={handleMoveChapter}
+                        activeChapterDrag={activeChapterDrag}
+                        getActiveChapterDrag={getActiveChapterDrag}
+                        onChapterDragStart={beginChapterDrag}
+                        onChapterDragEnd={clearActiveChapterDrag}
+                        chapterMultiSelect={chapterMultiSelect}
+                        checked={ch.id != null && selectedChapterIds.has(ch.id)}
+                        onToggleSelect={() => ch.id != null && toggleChapterSelect(ch.id)}
+                      />
+                    ))}
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-20 text-text-muted gap-3">
+            <div className="text-4xl opacity-20">📖</div>
+            <p className="text-sm">选择左侧的卷开始编辑，或点击「批量生成卷级大纲」</p>
+          </div>
+        )}
       </div>
     </PanelLayout>
+  )
+}
+
+// ── 预览面板 ──
+
+function PreviewPanel({
+  label, items, onConfirm, onCancel,
+}: {
+  label: string
+  items: { title: string; summary: string }[]
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  return (
+    <div className="border border-accent/50 rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-2 bg-accent/10">
+        <span className="text-sm font-medium text-accent">{label}</span>
+        <div className="flex gap-2">
+          <button onClick={onCancel}
+            className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text-primary rounded transition-colors">
+            <X className="w-3 h-3" /> 取消
+          </button>
+          <button onClick={onConfirm}
+            className="flex items-center gap-1 px-3 py-1 text-xs bg-accent text-white rounded hover:bg-accent-hover transition-colors">
+            <Check className="w-3 h-3" /> 确认写入
+          </button>
+        </div>
+      </div>
+      <div className="divide-y divide-border max-h-60 overflow-y-auto">
+        {items.map((item, i) => (
+          <div key={i} className="px-3 py-2 bg-bg-surface">
+            <div className="text-sm font-medium text-text-primary">{item.title}</div>
+            {item.summary && (
+              <div className="text-xs text-text-muted mt-1 line-clamp-2">{item.summary}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── 章节行 ──
+
+function ChapterRow({
+  ch,
+  idx,
+  onUpdate,
+  onDelete,
+  onOpen,
+  dnd,
+  onInsertAfter,
+  onGenerate,
+  parentId,
+  onMoveChapter,
+  activeChapterDrag,
+  getActiveChapterDrag,
+  onChapterDragStart,
+  onChapterDragEnd,
+  chapterMultiSelect,
+  checked,
+  onToggleSelect,
+}: {
+  ch: { id?: number; title: string; summary: string }
+  idx: number
+  onUpdate: (id: number, patch: Record<string, string>) => void
+  onDelete: (id: number) => void
+  onOpen?: (id: number) => void
+  dnd?: ItemDnD
+  onInsertAfter?: () => void
+  onGenerate?: () => void
+  parentId?: number
+  onMoveChapter?: (chapterId: number, targetParentId: number, index: number) => Promise<void>
+  activeChapterDrag: ChapterDragPayload | null
+  getActiveChapterDrag: GetActiveChapterDrag
+  onChapterDragStart: (payload: ChapterDragPayload) => void
+  onChapterDragEnd: () => void
+  chapterMultiSelect?: boolean
+  checked?: boolean
+  onToggleSelect?: () => void
+}) {
+  // FB-3:章节摘要(章节大纲)由单行 input 升级为多行自增 textarea —— 单行下改 1-2 句大纲很难受
+  //       (横向滚、看不全、改中间费劲)。本地草稿 + 失焦保存(IME 安全:组合输入结束后才 onBlur 写库)。
+  const [summaryDraft, setSummaryDraft] = useState(ch.summary || '')
+  const taRef = useRef<HTMLTextAreaElement>(null)
+  useEffect(() => { setSummaryDraft(ch.summary || '') }, [ch.summary])
+  useEffect(() => {
+    const ta = taRef.current
+    if (ta) { ta.style.height = 'auto'; ta.style.height = `${ta.scrollHeight}px` }
+  }, [summaryDraft])
+
+  const multiSelectActive = !!chapterMultiSelect
+  const crossParentDrop = !multiSelectActive && parentId != null && onMoveChapter
+    ? chapterDropProps({
+      targetParentId: parentId,
+      targetIndex: idx,
+      onMoveChapter,
+      getActiveChapterDrag,
+      clearActiveChapterDrag: onChapterDragEnd,
+    })
+    : null
+  const baseDropProps = !multiSelectActive ? dnd?.dropProps : undefined
+  const isCrossParentTarget = !multiSelectActive && activeChapterDrag != null && activeChapterDrag.sourceParentId !== parentId
+  const isOver = !multiSelectActive && (dnd?.isOver || isCrossParentTarget)
+
+  return (
+    <div
+      {...(baseDropProps ?? {})}
+      onDragOver={(event) => {
+        if (multiSelectActive) return
+        if (isCrossParentTarget) {
+          crossParentDrop?.onDragOver(event)
+          return
+        }
+        baseDropProps?.onDragOver(event)
+      }}
+      onDrop={(event) => {
+        if (multiSelectActive) return
+        const payload = readChapterDragPayload(event) ?? getActiveChapterDrag()
+        if (crossParentDrop && payload && payload.sourceParentId !== parentId) {
+          void crossParentDrop.onDrop(event)
+          return
+        }
+        baseDropProps?.onDrop(event)
+      }}
+      className={`flex items-start gap-1 px-2 py-2 bg-bg-surface border rounded-md group transition-colors ${
+        multiSelectActive && checked
+          ? 'border-accent ring-1 ring-accent/40 bg-accent/5'
+          : isOver
+            ? 'border-accent ring-1 ring-accent/50'
+            : 'border-border hover:border-accent/30'
+      } ${dnd?.isDragging ? 'opacity-40' : ''}`}
+    >
+      {/* 多选模式下显示复选框；否则显示拖拽手柄 */}
+      {multiSelectActive ? (
+        <button
+          onClick={() => onToggleSelect?.()}
+          className="shrink-0 mt-1 text-text-muted hover:text-accent"
+          title={checked ? '取消选中' : '选中'}
+        >
+          {checked
+            ? <CheckSquare className="w-4 h-4 text-accent" />
+            : <Square className="w-4 h-4" />}
+        </button>
+      ) : dnd && (
+        <span
+          {...dnd.dragHandleProps}
+          onDragStart={(event) => {
+            dnd.dragHandleProps.onDragStart(event)
+            if (ch.id != null) {
+              const payload = {
+                chapterId: ch.id,
+                sourceParentId: parentId ?? null,
+              } satisfies ChapterDragPayload
+              onChapterDragStart(payload)
+              event.dataTransfer.setData(OUTLINE_CHAPTER_DRAG_MIME, JSON.stringify(payload))
+            }
+          }}
+          onDragEnd={() => {
+            dnd.dragHandleProps.onDragEnd()
+            onChapterDragEnd()
+          }}
+          data-outline-chapter-id={ch.id}
+          title="拖动调整章节顺序"
+          className="shrink-0 mt-1 cursor-grab active:cursor-grabbing text-text-muted/40 group-hover:text-text-muted"
+        >
+          <GripVertical className="w-3.5 h-3.5" />
+        </span>
+      )}
+      <span className="text-xs text-text-muted mt-1.5 shrink-0 w-5 text-right">{idx + 1}</span>
+      <div className="flex-1 min-w-0">
+        <CInput
+          value={ch.title}
+          onChange={e => onUpdate(ch.id!, { title: e.target.value })}
+          className="w-full bg-transparent text-text-primary text-sm font-medium outline-none"
+        />
+        <textarea
+          ref={taRef}
+          value={summaryDraft}
+          onChange={e => setSummaryDraft(e.target.value)}
+          onBlur={() => { if (ch.id != null && summaryDraft !== (ch.summary || '')) onUpdate(ch.id, { summary: summaryDraft }) }}
+          rows={1}
+          placeholder="章节摘要（可编辑，失焦自动保存）"
+          className="w-full bg-transparent text-text-muted text-xs outline-none mt-0.5 resize-none overflow-hidden leading-relaxed"
+        />
+      </div>
+      {/* 多选模式下隐藏右侧操作按钮 */}
+      {!multiSelectActive && (
+        <div className={`flex items-center gap-0.5 transition-opacity shrink-0 mt-1 ${
+          !ch.summary.trim() && onGenerate ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+        }`}>
+          {!ch.summary.trim() && onGenerate && (
+            <button onClick={onGenerate} className="p-1 text-text-muted hover:text-accent rounded" title="AI 生成本章章纲">
+              <Sparkles className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {onInsertAfter && (
+            <button onClick={onInsertAfter} className="p-1 text-text-muted hover:text-accent rounded" title="在此章下方插入一章">
+              <CornerDownRight className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {onOpen && (
+            <button onClick={() => onOpen(ch.id!)} className="p-1 text-text-muted hover:text-accent rounded" title="编辑章节">
+              <ChevronRight className="w-3.5 h-3.5" />
+            </button>
+          )}
+          <button onClick={() => onDelete(ch.id!)} className="p-1 text-text-muted hover:text-error rounded">
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── 故事块区域 ──
+
+function StoryBlockSection({
+  block,
+  chapters,
+  onUpdateNode,
+  onDeleteNode,
+  onAddChapter,
+  onOpenChapter,
+  onReorder,
+  onInsertAfter,
+  onGenerateChapter,
+  onMoveChapter,
+  activeChapterDrag,
+  getActiveChapterDrag,
+  onChapterDragStart,
+  onChapterDragEnd,
+  chapterMultiSelect,
+  selectedChapterIds,
+  onToggleChapterSelect,
+}: {
+  block: { id?: number; title: string; summary: string }
+  chapters: { id?: number; title: string; summary: string }[]
+  onUpdateNode: (id: number, patch: Record<string, string>) => void
+  onDeleteNode: (id: number) => void
+  onAddChapter: () => void
+  onOpenChapter?: (id: number) => void
+  onReorder: (orderedIds: number[]) => void
+  onInsertAfter: (chapterId: number) => void
+  onGenerateChapter: (chapterId: number) => void
+  onMoveChapter: (chapterId: number, targetParentId: number, index: number) => Promise<void>
+  activeChapterDrag: ChapterDragPayload | null
+  getActiveChapterDrag: GetActiveChapterDrag
+  onChapterDragStart: (payload: ChapterDragPayload) => void
+  onChapterDragEnd: () => void
+  chapterMultiSelect?: boolean
+  selectedChapterIds?: Set<number>
+  onToggleChapterSelect?: (chapterId: number) => void
+}) {
+  const dialog = useDialog()
+  const [expanded, setExpanded] = useState(true)
+  const blockChaptersDnD = useDragReorder(chapters.map(c => c.id), onReorder)
+  const handleDeleteBlock = async () => {
+    if (!block.id) return
+    const ok = await dialog.confirm({
+      title: `删除故事块「${block.title}」？`,
+      message: '其下章节也会被删除，此操作不可恢复。',
+      confirmText: '删除',
+      tone: 'danger',
+    })
+    if (ok) onDeleteNode(block.id)
+  }
+  const multiSelectActive = !!chapterMultiSelect
+  const dropToBlockEnd = !multiSelectActive && block.id != null
+    ? chapterDropProps({
+      targetParentId: block.id,
+      targetIndex: chapters.length,
+      onMoveChapter,
+      getActiveChapterDrag,
+      clearActiveChapterDrag: onChapterDragEnd,
+    })
+    : null
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      {/* 故事块头 */}
+      <div
+        onDragOver={(event) => { if (!multiSelectActive) dropToBlockEnd?.onDragOver(event) }}
+        onDrop={(event) => { if (!multiSelectActive && dropToBlockEnd) void dropToBlockEnd.onDrop(event) }}
+        className="flex items-center gap-2 px-3 py-2 bg-bg-elevated"
+      >
+        <button onClick={() => setExpanded(!expanded)} className="text-text-muted hover:text-text-primary">
+          {expanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+        </button>
+        <LayoutList className="w-3.5 h-3.5 text-accent/60" />
+        <CInput
+          value={block.title}
+          onChange={e => onUpdateNode(block.id!, { title: e.target.value })}
+          className="flex-1 bg-transparent text-text-primary text-sm font-medium outline-none"
+        />
+        <span className="text-[10px] text-text-muted">{chapters.length} 章</span>
+        {!multiSelectActive && (
+          <>
+            <button onClick={onAddChapter} className="p-1 text-text-muted hover:text-accent rounded" title="添加章节">
+              <Plus className="w-3 h-3" />
+            </button>
+            <button onClick={() => { void handleDeleteBlock() }} className="p-1 text-text-muted hover:text-error rounded">
+              <Trash2 className="w-3 h-3" />
+            </button>
+          </>
+        )}
+      </div>
+      {/* 故事块摘要（多选模式下隐藏，节省空间） */}
+      {!multiSelectActive && (
+        <CInput
+          value={block.summary}
+          onChange={e => onUpdateNode(block.id!, { summary: e.target.value })}
+          placeholder="故事块描述..."
+          className="w-full px-3 py-1.5 bg-bg-surface text-text-muted text-xs border-b border-border focus:outline-none"
+        />
+      )}
+      {/* 章节列表 */}
+      {expanded && (
+        <div className="p-2 space-y-1">
+          {chapters.length === 0 ? (
+            multiSelectActive ? (
+              <div className="text-center py-3 text-text-muted text-xs">无章节</div>
+            ) : (
+              <div
+                onDragOver={(event) => dropToBlockEnd?.onDragOver(event)}
+                onDrop={(event) => { if (dropToBlockEnd) void dropToBlockEnd.onDrop(event) }}
+                className="text-center py-3 text-text-muted text-xs border border-dashed border-transparent hover:border-accent/40 rounded"
+              >
+                点击 + 添加章节
+              </div>
+            )
+          ) : (
+            chapters.map((ch, idx) => (
+              <ChapterRow
+                key={ch.id} ch={ch} idx={idx}
+                onUpdate={onUpdateNode} onDelete={onDeleteNode} onOpen={onOpenChapter}
+                dnd={blockChaptersDnD.itemDnD(ch.id)}
+                onInsertAfter={() => onInsertAfter(ch.id!)}
+                onGenerate={() => onGenerateChapter(ch.id!)}
+                parentId={block.id!}
+                onMoveChapter={onMoveChapter}
+                activeChapterDrag={activeChapterDrag}
+                getActiveChapterDrag={getActiveChapterDrag}
+                onChapterDragStart={onChapterDragStart}
+                onChapterDragEnd={onChapterDragEnd}
+                chapterMultiSelect={chapterMultiSelect}
+                checked={ch.id != null && selectedChapterIds?.has(ch.id)}
+                onToggleSelect={() => ch.id != null && onToggleChapterSelect?.(ch.id)}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── 故事结构选择菜单 ──
+
+function StructureMenu({ onSelect }: { onSelect: (s: StoryStructure) => void }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="relative">
+      <button onClick={() => setOpen(!open)}
+        className="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-accent border border-border rounded-md transition-colors">
+        <LayoutList className="w-3 h-3" /> 添加故事结构
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-full mt-1 z-20 bg-bg-elevated border border-border rounded-lg shadow-lg py-1 min-w-[160px]">
+            {(Object.entries(STORY_STRUCTURES) as [StoryStructure, { label: string; blocks: string[] }][]).map(([key, def]) => (
+              <button key={key} onClick={() => { onSelect(key); setOpen(false) }}
+                className="w-full px-3 py-1.5 text-left text-xs text-text-primary hover:bg-bg-hover transition-colors">
+                <span className="font-medium">{def.label}</span>
+                {def.blocks.length > 0 && (
+                  <span className="text-text-muted ml-1">（{def.blocks.length} 块）</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
   )
 }

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -1,22 +1,14 @@
-import { useState, useEffect, useRef, useSyncExternalStore } from 'react'
-import { Eye, EyeOff, CheckCircle, RotateCcw, RefreshCw } from 'lucide-react'
+import { useState, useEffect, useSyncExternalStore } from 'react'
+import { Wifi, WifiOff, Eye, EyeOff, CheckCircle, Trash2, ScrollText, Loader2, ChevronDown, Check } from 'lucide-react'
 import { useAIConfigStore, type TestResult } from '../../stores/ai-config'
 import EmbeddingConfigCard from './EmbeddingConfigCard'
 import type { AIProvider } from '../../lib/types'
 import { PROVIDER_MODELS } from '../../lib/types'
 import { isAIConfigReady } from '../../lib/ai/config-readiness'
-import { getLogs, subscribeLogs, clearLogs } from '../../lib/ai/logger'
-import { applyStoryForgeTheme, resolveStoryForgeTheme, type StoryForgeTheme } from '../../lib/theme'
+import { getLogs, subscribeLogs, clearLogs, formatLog } from '../../lib/ai/logger'
+import { applyStoryForgeTheme, resolveStoryForgeTheme, THEME_OPTIONS, type StoryForgeTheme } from '../../lib/theme'
 import { useDialog } from '../shared/Dialog'
-import { parseContextWindowInput } from '../../lib/ai/context-window-input'
-import { fetchOpenAIModels } from '../../lib/ai/model-list'
 import { normalizeOpenAIBaseUrl } from '../../lib/ai/openai-endpoint'
-import { AI_PROXY_ENDPOINTS } from '../../lib/ai/proxy-endpoints'
-import AIConfigPresetSection from './AIConfigPresetSection'
-import AITaskRoutingSection from './AITaskRoutingSection'
-import AIConnectionLogPanel from './AIConnectionLogPanel'
-import AIConnectionTestSection from './AIConnectionTestSection'
-import ThemeSelector from './ThemeSelector'
 
 export const PROVIDER_OPTIONS: { value: AIProvider; label: string; cors: boolean; hint: string }[] = [
   { value: 'deepseek', label: 'DeepSeek', cors: false, hint: '获取 Key: platform.deepseek.com → API Keys（需点击下方「切换到本地代理」）' },
@@ -42,7 +34,7 @@ export const PROVIDER_OPTIONS: { value: AIProvider; label: string; cors: boolean
 export default function AIConfigPanel() {
   const { config, setConfig, switchProvider, testConnection,
     rememberApiKey, setRememberApiKey,
-    presets, taskRoutes, setTaskRoute, activePresetId, editingPresetId, saveAsPreset, applyPreset, updatePresetFromCurrent, renamePreset, deletePreset } = useAIConfigStore()
+    presets, activePresetId, editingPresetId, saveAsPreset, applyPreset, updatePresetFromCurrent, renamePreset, deletePreset } = useAIConfigStore()
   const dialog = useDialog()
   const [showKey, setShowKey] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -50,15 +42,14 @@ export default function AIConfigPanel() {
   const [showLogs, setShowLogs] = useState(false)
   const [savingPreset, setSavingPreset] = useState(false)
   const [presetName, setPresetName] = useState('')
-  const [contextWindowDraft, setContextWindowDraft] = useState(() => config.contextWindow ? String(config.contextWindow) : '')
-  const [contextWindowError, setContextWindowError] = useState('')
-  const [fetchedModels, setFetchedModels] = useState<string[]>([])
-  const [refreshingModels, setRefreshingModels] = useState(false)
-  const [modelListError, setModelListError] = useState('')
-  const submittedContextWindowRef = useRef(config.contextWindow)
   const [currentTheme, setCurrentTheme] = useState<StoryForgeTheme>(() =>
     resolveStoryForgeTheme(localStorage.getItem('storyforge-theme')),
   )
+  // 模型拉取（点「连接」按钮调用 /v1/models 列出可用模型）
+  const [fetchingModels, setFetchingModels] = useState(false)
+  const [fetchedModels, setFetchedModels] = useState<string[]>([])
+  const [fetchModelsError, setFetchModelsError] = useState<string | null>(null)
+  const [showModelsDropdown, setShowModelsDropdown] = useState(false)
 
   const handleSavePreset = () => {
     if (!presetName.trim()) return
@@ -73,47 +64,6 @@ export default function AIConfigPanel() {
   const currentProviderInfo = PROVIDER_OPTIONS.find((p) => p.value === config.provider)
   const editingPreset = editingPresetId ? presets.find(p => p.id === editingPresetId) : null
 
-  useEffect(() => {
-    if (config.contextWindow === submittedContextWindowRef.current) return
-    submittedContextWindowRef.current = config.contextWindow
-    setContextWindowDraft(config.contextWindow ? String(config.contextWindow) : '')
-    setContextWindowError('')
-  }, [config.contextWindow])
-
-  const handleContextWindowChange = (raw: string) => {
-    setContextWindowDraft(raw)
-    const parsed = parseContextWindowInput(raw)
-    if (parsed.kind === 'invalid') {
-      setContextWindowError(parsed.message)
-      return
-    }
-
-    const next = parsed.kind === 'valid' ? parsed.value : undefined
-    setContextWindowError('')
-    submittedContextWindowRef.current = next
-    setConfig({ contextWindow: next })
-  }
-
-  const handleRefreshModels = async () => {
-    setRefreshingModels(true)
-    setModelListError('')
-    try {
-      const normalized = normalizeOpenAIBaseUrl(config.baseUrl)
-      if (normalized.changed) setConfig({ baseUrl: normalized.baseUrl })
-      const models = await fetchOpenAIModels({
-        baseUrl: normalized.baseUrl,
-        apiKey: config.apiKey,
-      })
-      setFetchedModels(models)
-      if (models.length === 0) setModelListError('服务返回了空模型列表；仍可手动填写模型名')
-    } catch (error) {
-      setFetchedModels([])
-      setModelListError(error instanceof Error ? error.message : '刷新模型列表失败')
-    } finally {
-      setRefreshingModels(false)
-    }
-  }
-
   const handleTest = async () => {
     setTesting(true)
     setTestResult(null)
@@ -123,6 +73,57 @@ export default function AIConfigPanel() {
     } finally {
       setTesting(false)
     }
+  }
+
+  // 拉取模型列表：用当前 baseUrl + apiKey 调用 /v1/models 端点
+  const handleFetchModels = async () => {
+    if (!config.baseUrl.trim()) {
+      setFetchModelsError('请先填写 Base URL')
+      return
+    }
+    setFetchingModels(true)
+    setFetchModelsError(null)
+    setFetchedModels([])
+    setShowModelsDropdown(true)
+    try {
+      const normalized = normalizeOpenAIBaseUrl(config.baseUrl)
+      // 若 normalize 改了 baseUrl，顺手写回 config（与测试连接行为一致）
+      if (normalized.changed) {
+        setConfig({ baseUrl: normalized.baseUrl })
+      }
+      const url = `${normalized.baseUrl}/models`
+      const res = await fetch(url, {
+        headers: {
+          ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+          'Content-Type': 'application/json',
+        },
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`HTTP ${res.status} ${res.statusText}${text ? ` · ${text.slice(0, 200)}` : ''}`)
+      }
+      const json = await res.json()
+      // OpenAI 标准：{ data: [{ id: "..." }, ...] }；部分兼容服务返回数组或 { models: [...] }
+      const list: unknown[] = Array.isArray(json?.data) ? json.data
+        : Array.isArray(json?.models) ? json.models
+        : Array.isArray(json) ? json
+        : []
+      const ids = list
+        .map((m: unknown) => typeof m === 'string' ? m : (m as { id?: string; model?: string })?.id ?? (m as { model?: string })?.model)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+        .sort((a, b) => a.localeCompare(b))
+      if (ids.length === 0) throw new Error('服务器返回了空模型列表')
+      setFetchedModels(ids)
+    } catch (err) {
+      setFetchModelsError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setFetchingModels(false)
+    }
+  }
+
+  const handleSelectFetchedModel = (modelId: string) => {
+    setConfig({ model: modelId })
+    setShowModelsDropdown(false)
   }
 
   const handleThemeChange = (theme: StoryForgeTheme) => {
@@ -149,15 +150,13 @@ export default function AIConfigPanel() {
     if (ok) deletePreset(id)
   }
 
-  // 切换 provider 时清空测试结果
+  // 切换 provider 时清空测试结果和已拉取的模型
   useEffect(() => {
     setTestResult(null)
-  }, [config.provider])
-
-  useEffect(() => {
     setFetchedModels([])
-    setModelListError('')
-  }, [config.baseUrl, config.provider])
+    setFetchModelsError(null)
+    setShowModelsDropdown(false)
+  }, [config.provider])
 
   return (
     <div className="max-w-2xl">
@@ -170,23 +169,87 @@ export default function AIConfigPanel() {
           API Key 默认仅保存在本次浏览器会话；勾选“记住在本机”才会写入 localStorage。发起 AI 生成、测试连接或使用自定义 baseUrl 时，相关提示词和上下文会发送到你配置的模型服务。
         </p>
 
-        <AIConfigPresetSection
-          presets={presets}
-          activePresetId={activePresetId}
-          editingPreset={editingPreset ?? null}
-          savingPreset={savingPreset}
-          presetName={presetName}
-          onPresetNameChange={setPresetName}
-          onStartSaving={() => setSavingPreset(true)}
-          onCancelSaving={() => setSavingPreset(false)}
-          onSavePreset={handleSavePreset}
-          onApplyPreset={applyPreset}
-          onUpdatePreset={updatePresetFromCurrent}
-          onRenamePreset={(id, name) => { void handleRenamePreset(id, name) }}
-          onDeletePreset={(id, name) => { void handleDeletePreset(id, name) }}
-        />
+        {/* ── API 配置预设（多套一键切换） ── */}
+        <div className="mb-4 pb-4 border-b border-border/50">
+          <div className="flex items-center justify-between mb-2">
+            <label className="text-sm text-text-secondary">配置预设</label>
+            {editingPreset && !savingPreset ? (
+              <div className="flex items-center gap-1.5">
+                <button
+                  onClick={() => updatePresetFromCurrent(editingPreset.id)}
+                  title={`用当前表单内容覆盖「${editingPreset.name}」`}
+                  className="text-xs px-2.5 py-1 rounded-lg bg-accent text-white hover:bg-accent-hover transition-colors"
+                >
+                  保存修改到「{editingPreset.name}」
+                </button>
+                <button
+                  onClick={() => setSavingPreset(true)}
+                  className="text-xs px-2.5 py-1 rounded-lg bg-bg-elevated text-text-secondary border border-border hover:text-accent hover:border-accent/50 transition-colors"
+                >
+                  另存为新预设
+                </button>
+              </div>
+            ) : savingPreset ? (
+              <div className="flex items-center gap-1.5">
+                <input
+                  autoFocus
+                  value={presetName}
+                  onChange={e => setPresetName(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') handleSavePreset(); if (e.key === 'Escape') setSavingPreset(false) }}
+                  placeholder="预设名称，如「DeepSeek 主力」"
+                  className="px-2 py-1 bg-bg-base border border-border rounded text-xs text-text-primary focus:outline-none focus:border-accent w-44"
+                />
+                <button onClick={handleSavePreset} className="px-2 py-1 text-xs bg-accent text-white rounded hover:bg-accent-hover">保存</button>
+                <button onClick={() => setSavingPreset(false)} className="px-2 py-1 text-xs text-text-muted hover:text-text-primary">取消</button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setSavingPreset(true)}
+                className="text-xs px-2.5 py-1 rounded-lg bg-bg-elevated text-text-secondary border border-border hover:text-accent hover:border-accent/50 transition-colors"
+              >
+                ＋ 保存当前为预设
+              </button>
+            )}
+          </div>
 
-        <AITaskRoutingSection presets={presets} routes={taskRoutes} onSetRoute={setTaskRoute} />
+          {presets.length === 0 ? (
+            <p className="text-xs text-text-muted">还没有预设。配好一套 API 后点「保存当前为预设」，之后可一键切换。</p>
+          ) : (
+            <div className="flex items-center gap-1.5 flex-wrap">
+              {presets.map(p => (
+                <div
+                  key={p.id}
+                  className={`group flex items-center gap-1 pl-2.5 pr-1 py-1 text-xs rounded-full border transition-colors ${
+                    activePresetId === p.id
+                      ? 'bg-accent text-white border-accent'
+                      : 'bg-bg-base text-text-secondary border-border hover:border-accent/50'
+                  }`}
+                >
+                  <button onClick={() => applyPreset(p.id)} title={`${p.config.provider} · ${p.config.model}`}>
+                    {p.name}
+                  </button>
+                  {activePresetId === p.id && (
+                    <button
+                      onClick={() => updatePresetFromCurrent(p.id)}
+                      title="用当前配置覆盖此预设"
+                      className="opacity-70 hover:opacity-100"
+                    >保存</button>
+                  )}
+                  <button
+                    onClick={() => { void handleRenamePreset(p.id, p.name) }}
+                    title="重命名"
+                    className="opacity-0 group-hover:opacity-70 hover:opacity-100"
+                  >✎</button>
+                  <button
+                    onClick={() => { void handleDeletePreset(p.id, p.name) }}
+                    title="删除"
+                    className="opacity-0 group-hover:opacity-70 hover:opacity-100 hover:text-red-400"
+                  >✕</button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
 
         <div className="space-y-4">
           <div>
@@ -271,7 +334,19 @@ export default function AIConfigPanel() {
                 </p>
               )}
               {(() => {
-                const pm = AI_PROXY_ENDPOINTS[config.provider]
+                // 需要代理的 provider 及其代理路径 / 原始地址映射
+                const PROXY_MAP: Record<string, { proxy: string; direct: string }> = {
+                  deepseek: { proxy: '/deepseek-proxy/v1', direct: 'https://api.deepseek.com/v1' },
+                  openai:   { proxy: '/openai-proxy/v1',   direct: 'https://api.openai.com/v1' },
+                  kimi:     { proxy: '/kimi-proxy/v1',     direct: 'https://api.moonshot.cn/v1' },
+                  claude:   { proxy: '/claude-proxy/v1',   direct: 'https://api.anthropic.com/v1' },
+                  nvidia:   { proxy: '/nvidia-proxy/v1',   direct: 'https://integrate.api.nvidia.com/v1' },
+                  doubao:   { proxy: '/doubao-proxy/api/v3', direct: 'https://ark.cn-beijing.volces.com/api/v3' },
+                  agnes:    { proxy: '/agnes-proxy/v1',    direct: 'https://apihub.agnes-ai.com/v1' },
+                  longcat:  { proxy: '/longcat-proxy/openai/v1', direct: 'https://api.longcat.chat/openai/v1' },
+                  opencode: { proxy: '/opencode-proxy/v1',  direct: 'https://opencode.ai/zen/go/v1' },
+                }
+                const pm = PROXY_MAP[config.provider]
                 if (!pm) return null
                 const isProxy = config.baseUrl.startsWith('/' + config.provider)
                 return (
@@ -296,32 +371,7 @@ export default function AIConfigPanel() {
               })()}
             </div>
             <div>
-              <div className="mb-1.5 flex items-center justify-between gap-2">
-                <label className="block text-sm text-text-secondary">模型</label>
-                {['custom', 'ollama'].includes(config.provider) && (
-                  <button
-                    type="button"
-                    onClick={() => { void handleRefreshModels() }}
-                    disabled={refreshingModels || !config.baseUrl.trim()}
-                    title="从当前服务刷新模型列表"
-                    className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-accent hover:bg-accent/10 disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    <RefreshCw className={`h-3.5 w-3.5 ${refreshingModels ? 'animate-spin' : ''}`} />
-                    {refreshingModels ? '刷新中' : '刷新模型'}
-                  </button>
-                )}
-              </div>
-              {['custom', 'ollama'].includes(config.provider) && fetchedModels.length > 0 && (
-                <select
-                  value={fetchedModels.includes(config.model) ? config.model : ''}
-                  onChange={(e) => { if (e.target.value) setConfig({ model: e.target.value }) }}
-                  aria-label="服务返回的模型列表"
-                  className="mb-1.5 w-full rounded-lg border border-border bg-bg-base px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
-                >
-                  <option value="">选择服务返回的模型（{fetchedModels.length}）</option>
-                  {fetchedModels.map(model => <option key={model} value={model}>{model}</option>)}
-                </select>
-              )}
+              <label className="block text-sm text-text-secondary mb-1.5">模型</label>
               {PROVIDER_MODELS[config.provider] ? (
                 <>
                   <select
@@ -355,13 +405,58 @@ export default function AIConfigPanel() {
                   type="text"
                   value={config.model}
                   onChange={(e) => setConfig({ model: e.target.value })}
-                  placeholder="手动输入模型名"
                   className="w-full px-3 py-2 bg-bg-base border border-border rounded-lg text-text-primary text-sm focus:outline-none focus:border-accent transition-colors"
                 />
               )}
-              {modelListError && <p className="mt-1 text-[11px] text-amber-400">{modelListError}</p>}
-              {config.provider === 'ollama' && (
-                <p className="mt-1 text-[11px] text-text-muted">未安装的模型请先在 Ollama 中拉取，完成后回到这里刷新。</p>
+
+              {/* 连接拉取模型按钮 + 下拉 */}
+              <div className="mt-1.5 relative">
+                <button
+                  onClick={handleFetchModels}
+                  disabled={fetchingModels || !config.baseUrl.trim()}
+                  className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs bg-bg-elevated text-text-secondary rounded-md hover:text-accent border border-border hover:border-accent/50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  title="用当前 Base URL + API Key 拉取可用模型列表"
+                >
+                  {fetchingModels ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Wifi className="w-3.5 h-3.5" />}
+                  {fetchingModels ? '拉取中...' : '连接拉取模型'}
+                </button>
+                {fetchedModels.length > 0 && !showModelsDropdown && (
+                  <button
+                    onClick={() => setShowModelsDropdown(true)}
+                    className="ml-1.5 inline-flex items-center gap-1 px-2 py-1.5 text-xs text-text-muted hover:text-accent transition-colors"
+                    title="展开已拉取的模型列表"
+                  >
+                    <ChevronDown className="w-3 h-3" /> 已拉取 {fetchedModels.length} 个
+                  </button>
+                )}
+
+                {/* 拉取到的模型列表 */}
+                {showModelsDropdown && (
+                  <>
+                    <div className="fixed inset-0 z-10" onClick={() => setShowModelsDropdown(false)} />
+                    <div className="absolute z-20 left-0 top-full mt-1 w-full max-h-60 overflow-y-auto bg-bg-elevated border border-border rounded-lg shadow-lg py-1">
+                      <div className="px-2 py-1 text-[10px] text-text-muted flex items-center justify-between border-b border-border/50 sticky top-0 bg-bg-elevated">
+                        <span>共 {fetchedModels.length} 个模型 · 点选填入</span>
+                        <button onClick={() => setShowModelsDropdown(false)} className="text-text-muted hover:text-text-primary">✕</button>
+                      </div>
+                      {fetchedModels.map(id => (
+                        <button
+                          key={id}
+                          onClick={() => handleSelectFetchedModel(id)}
+                          className={`w-full px-2 py-1.5 text-left text-xs flex items-center justify-between gap-2 hover:bg-bg-hover transition-colors ${
+                            config.model === id ? 'text-accent bg-accent/5' : 'text-text-primary'
+                          }`}
+                        >
+                          <span className="truncate font-mono">{id}</span>
+                          {config.model === id && <Check className="w-3 h-3 shrink-0" />}
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+              {fetchModelsError && (
+                <p className="mt-1 text-xs text-red-500 break-all">拉取失败：{fetchModelsError}</p>
               )}
             </div>
           </div>
@@ -427,54 +522,65 @@ export default function AIConfigPanel() {
                 ? <span className="text-accent ml-1">{config.contextWindow.toLocaleString()} token</span>
                 : <span className="text-text-muted ml-1">按模型预设</span>}
             </label>
-            <div className="flex items-center gap-2">
-              <input
-                type="text"
-                inputMode="numeric"
-                value={contextWindowDraft}
-                onChange={(e) => handleContextWindowChange(e.target.value)}
-                aria-invalid={Boolean(contextWindowError)}
-                placeholder="本地/自定义模型请按实际填写，如 131072；留空 = 用内置预设"
-                className={`min-w-0 flex-1 px-3 py-2 bg-bg-base border rounded text-sm text-text-primary focus:outline-none ${contextWindowError ? 'border-red-400 focus:border-red-400' : 'border-border focus:border-accent'}`}
-              />
-              <button
-                type="button"
-                onClick={() => handleContextWindowChange('')}
-                disabled={!contextWindowDraft && !contextWindowError}
-                title="重置为模型预设"
-                aria-label="重置上下文窗口为模型预设"
-                className="p-2 rounded border border-border text-text-muted hover:text-accent hover:border-accent/50 disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <RotateCcw className="w-4 h-4" />
-              </button>
-            </div>
-            {contextWindowError ? (
-              <p className="mt-1 text-[11px] text-red-400">{contextWindowError}；已保存值未改变。</p>
-            ) : (
-              <p className="mt-1 flex items-center gap-1 text-[11px] text-green-400/80">
-                <CheckCircle className="w-3 h-3" />
-                {editingPreset && activePresetId === null
-                  ? `已自动保存到当前配置，尚未写回「${editingPreset.name}」`
-                  : '已自动保存到当前配置'}
-              </p>
-            )}
+            <input
+              type="number"
+              min={0}
+              value={config.contextWindow || ''}
+              onChange={(e) => setConfig({ contextWindow: Number(e.target.value) || undefined })}
+              placeholder="本地/自定义模型请按实际填写，如 131072；留空 = 用内置预设"
+              className="w-full px-3 py-2 bg-bg-base border border-border rounded text-sm text-text-primary focus:outline-none focus:border-accent"
+            />
             <p className="text-[11px] text-text-muted mt-1">
               识别不到的模型默认按 8K 计算,会误报「上下文超出窗口」。本地模型(LM Studio / Ollama)请在此填真实窗口,如 128000 / 262144。
             </p>
           </div>
 
           {/* 测试连接 */}
-          <AIConnectionTestSection
-            testing={testing}
-            result={testResult}
-            configReady={isAIConfigReady(config)}
-            provider={config.provider}
-            logCount={logs.length}
-            showLogs={showLogs}
-            isDevelopment={import.meta.env.DEV}
-            onTest={() => { void handleTest() }}
-            onToggleLogs={() => setShowLogs(!showLogs)}
-          />
+          <div className="pt-2 space-y-2">
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleTest}
+                disabled={testing || !isAIConfigReady(config)}
+                className="flex items-center gap-2 px-4 py-2 bg-accent/10 text-accent rounded-lg hover:bg-accent/20 disabled:opacity-40 transition-colors text-sm"
+              >
+                {testing ? (
+                  <span className="animate-spin">⏳</span>
+                ) : testResult?.ok ? (
+                  <CheckCircle className="w-4 h-4" />
+                ) : testResult && !testResult.ok ? (
+                  <WifiOff className="w-4 h-4" />
+                ) : (
+                  <Wifi className="w-4 h-4" />
+                )}
+                {testing ? '测试中...' : '测试连接'}
+              </button>
+              <button
+                onClick={() => setShowLogs(!showLogs)}
+                className="flex items-center gap-1.5 px-3 py-2 text-text-muted hover:text-text-secondary text-sm transition-colors"
+              >
+                <ScrollText className="w-4 h-4" />
+                日志 {logs.length > 0 && `(${logs.length})`}
+              </button>
+            </div>
+            {/* 测试结果详情 */}
+            {testResult && (
+              <div className={`text-sm px-3 py-2 rounded-lg ${testResult.ok ? 'bg-green-500/10 text-green-400' : 'bg-red-500/10 text-red-400'}`}>
+                <p>{testResult.message}</p>
+                {testResult.duration && (
+                  <p className="text-xs mt-0.5 opacity-70">耗时 {testResult.duration}ms</p>
+                )}
+              </div>
+            )}
+            {/* CORS 错误提示 */}
+            {testResult && !testResult.ok && config.provider === 'deepseek' &&
+              (testResult.message.includes('CORS') || testResult.message.includes('网络错误')) && (
+              <p className="text-xs text-amber-400 px-1">
+                {import.meta.env.DEV
+                  ? '💡 本地运行时，可点击「切换到本地代理」解决此问题'
+                  : '💡 建议改用 Gemini（支持浏览器直调）或在本地运行此工具'}
+              </p>
+            )}
+          </div>
         </div>
       </div>
 
@@ -482,10 +588,84 @@ export default function AIConfigPanel() {
       <EmbeddingConfigCard />
 
       {/* 日志面板 */}
-      {showLogs && <AIConnectionLogPanel logs={logs} onClear={clearLogs} />}
+      {showLogs && (
+        <div className="bg-bg-surface border border-border rounded-xl p-4 mb-6">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-semibold text-text-primary">连接日志</h3>
+            <button
+              onClick={clearLogs}
+              className="flex items-center gap-1 text-xs text-text-muted hover:text-text-secondary"
+            >
+              <Trash2 className="w-3 h-3" /> 清空
+            </button>
+          </div>
+          <div className="max-h-[200px] overflow-y-auto space-y-1 font-mono text-xs">
+            {logs.length === 0 ? (
+              <p className="text-text-muted">暂无日志，点击「测试连接」生成</p>
+            ) : (
+              logs.map((log) => (
+                <pre key={log.id} className="text-text-secondary whitespace-pre-wrap break-all">
+                  {formatLog(log)}
+                </pre>
+              ))
+            )}
+          </div>
+        </div>
+      )}
 
       {/* 主题切换 */}
-      <ThemeSelector value={currentTheme} onChange={handleThemeChange} />
+      <div className="bg-bg-surface border border-border rounded-xl p-5">
+        <h3 className="text-base font-semibold text-text-primary mb-4">主题</h3>
+        <div className="flex flex-col gap-3">
+          {THEME_OPTIONS.map((theme) => {
+            const isActive = currentTheme === theme.value
+            return (
+              <button
+                key={theme.value}
+                onClick={() => handleThemeChange(theme.value)}
+                className={`flex items-center gap-3 px-4 py-3 rounded-xl border text-left transition-all ${
+                  isActive
+                    ? 'border-accent bg-accent/10'
+                    : 'border-border hover:border-border-hover hover:bg-bg-hover'
+                }`}
+              >
+                {/* 色块预览 */}
+                <div className="flex items-end gap-1 flex-shrink-0">
+                  {theme.swatches.map((c, j) => (
+                    <div
+                      key={j}
+                      style={{
+                        width: j === 0 ? 28 : 18,
+                        height: j === 0 ? 28 : 18,
+                        background: c,
+                        borderRadius: j === 0 ? 6 : 4,
+                        border: '1px solid rgba(0,0,0,0.08)',
+                        marginBottom: j === 0 ? 0 : 5,
+                        flexShrink: 0,
+                      }}
+                    />
+                  ))}
+                </div>
+                {/* 文字 */}
+                <div className="flex-1">
+                  <p className="text-sm text-text-primary font-medium leading-none mb-1">
+                    {theme.emoji} {theme.label}
+                  </p>
+                  <p className="text-xs text-text-muted">{theme.desc}</p>
+                </div>
+                {/* 选中标记 */}
+                {isActive && (
+                  <div className="w-5 h-5 rounded-full bg-accent flex items-center justify-center flex-shrink-0">
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M20 6 9 17 4 12"/>
+                    </svg>
+                  </div>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/settings/prompt/PromptManagerPanel.tsx
+++ b/src/components/settings/prompt/PromptManagerPanel.tsx
@@ -5,7 +5,6 @@ import type { PromptTemplate } from '../../../lib/types/prompt'
 import type { Project } from '../../../lib/types'
 import { GENRE_PACKS } from '../../../lib/ai/prompt-seeds-genre-packs'
 import PromptTemplateList from './PromptTemplateList'
-import PromptTemplateEditor from './PromptTemplateEditor'
 import PromptWorkflowsPanel from './PromptWorkflowsPanel'
 import { useToast } from '../../shared/Toast'
 
@@ -66,7 +65,7 @@ export default function PromptManagerPanel({ project }: Props = {}) {
     return t.scope === scopeFilter
   })
 
-  const selected = selectedId ? templates.find(t => t.id === selectedId) : null
+  // selected 仅在 PromptTemplatesView 内通过 selectedId 索引，外层不再单独取对象
 
   /** 新建一个空模板（user scope） */
   const handleNew = async () => {
@@ -163,7 +162,6 @@ export default function PromptManagerPanel({ project }: Props = {}) {
         <PromptTemplatesView
           templates={templates}
           filtered={filtered}
-          selected={selected}
           selectedId={selectedId}
           setSelectedId={setSelectedId}
           scopeFilter={scopeFilter}
@@ -185,7 +183,6 @@ export default function PromptManagerPanel({ project }: Props = {}) {
 interface TemplatesViewProps {
   templates: PromptTemplate[]
   filtered: PromptTemplate[]
-  selected: PromptTemplate | null | undefined
   selectedId: number | null
   setSelectedId: (id: number | null) => void
   scopeFilter: ScopeFilter
@@ -201,7 +198,7 @@ interface TemplatesViewProps {
 }
 
 function PromptTemplatesView({
-  filtered, selected, selectedId, setSelectedId, scopeFilter, setScopeFilter,
+  filtered, selectedId, setSelectedId, scopeFilter, setScopeFilter,
   genrePack, handleGenrePackChange, handleNew, handleImportClick,
   handleExportAll, handleImportFile, fileInputRef, reload,
 }: TemplatesViewProps) {
@@ -273,22 +270,15 @@ function PromptTemplatesView({
         </div>
       </div>
 
-      {/* 主区：左列表 + 右编辑器 */}
-      <div className="flex-1 flex overflow-hidden">
-        <div className="w-80 flex-shrink-0 border-r border-border overflow-y-auto">
-          <PromptTemplateList
-            templates={filtered}
-            selectedId={selectedId}
-            onSelect={setSelectedId}
-          />
-        </div>
-        <div className="flex-1 overflow-y-auto">
-          <PromptTemplateEditor
-            template={selected ?? null}
-            onChanged={() => reload()}
-            onDeleted={() => setSelectedId(null)}
-          />
-        </div>
+      {/* 主区：两级网格 + 详情弹窗（全部由 PromptTemplateList 接管） */}
+      <div className="flex-1 overflow-y-auto">
+        <PromptTemplateList
+          templates={filtered}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          onChanged={() => reload()}
+          onDeleted={() => setSelectedId(null)}
+        />
       </div>
     </div>
   )

--- a/src/components/settings/prompt/PromptTemplateList.tsx
+++ b/src/components/settings/prompt/PromptTemplateList.tsx
@@ -1,22 +1,23 @@
-import { useState } from 'react'
-import { ChevronRight, ChevronDown, Star, User } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { ChevronRight, Star, User, ArrowLeft, X, FileText } from 'lucide-react'
 import type { PromptTemplate } from '../../../lib/types/prompt'
+import PromptTemplateEditor from './PromptTemplateEditor'
 
 /** moduleKey 的 UI 分组规则：第一个 . 之前的部分 */
-const GROUP_LABELS: Record<string, { label: string; emoji: string; order: number }> = {
-  worldview:  { label: '世界观',  emoji: '🌍', order: 1 },
-  research:   { label: '研究考证', emoji: '🔎', order: 2 },
-  character:  { label: '角色',    emoji: '🧙', order: 3 },
-  outline:    { label: '大纲',    emoji: '🗂', order: 4 },
-  chapter:    { label: '章节',    emoji: '✏️', order: 5 },
-  detail:     { label: '细纲',    emoji: '📝', order: 6 },
-  review:     { label: '审校',    emoji: '🧭', order: 7 },
-  foreshadow: { label: '伏笔',    emoji: '🎯', order: 8 },
-  geography:  { label: '地理',    emoji: '🗺', order: 9 },
-  story:      { label: '故事',    emoji: '📖', order: 10 },
-  rules:      { label: '创作规则', emoji: '📐', order: 11 },
-  prompt:     { label: 'Prompt 管理', emoji: '⚙️', order: 12 },
-  import:     { label: '导入解析', emoji: '📥', order: 13 },
+const GROUP_LABELS: Record<string, { label: string; emoji: string; order: number; desc: string }> = {
+  worldview:  { label: '世界观',  emoji: '🌍', order: 1, desc: '世界维度、世界规则' },
+  research:   { label: '研究考证', emoji: '🔎', order: 2, desc: '研究方法学' },
+  character:  { label: '角色',    emoji: '🧙', order: 3, desc: '角色生成与设计' },
+  outline:    { label: '大纲',    emoji: '🗂', order: 4, desc: '卷纲、章纲、结构' },
+  chapter:    { label: '章节',    emoji: '✏️', order: 5, desc: '正文创作与续写润色' },
+  detail:     { label: '细纲',    emoji: '📝', order: 6, desc: '场景与章场规划' },
+  review:     { label: '审校',    emoji: '🧭', order: 7, desc: '宏观与语言修订' },
+  foreshadow: { label: '伏笔',    emoji: '🎯', order: 8, desc: '伏笔生成' },
+  geography:  { label: '地理',    emoji: '🗺', order: 9, desc: '概念地图与图像 Prompt' },
+  story:      { label: '故事',    emoji: '📖', order: 10, desc: '故事核心与立项' },
+  rules:      { label: '创作规则', emoji: '📐', order: 11, desc: '创作风格规则' },
+  prompt:     { label: 'Prompt 管理', emoji: '⚙️', order: 12, desc: 'Prompt 运维操作' },
+  import:     { label: '导入解析', emoji: '📥', order: 13, desc: '解析导入文本' },
 }
 
 /** moduleKey 的二级标签（点号后部分） */
@@ -60,124 +61,185 @@ const SUB_LABELS: Record<string, string> = {
 
 interface Props {
   templates: PromptTemplate[]
-  selectedId: number | null
+  /** 外层仍传 selectedId，仅用于外部 store 同步（组件内部用 detailId） */
+  selectedId?: number | null
   onSelect: (id: number) => void
+  /** 编辑器变更后刷新（与原版一致） */
+  onChanged?: () => void
+  onDeleted?: () => void
 }
 
-export default function PromptTemplateList({ templates, selectedId, onSelect }: Props) {
-  // 按 moduleKey 第一段分组
-  const groups = new Map<string, PromptTemplate[]>()
-  for (const t of templates) {
-    const groupKey = t.moduleKey.split('.')[0]
-    if (!groups.has(groupKey)) groups.set(groupKey, [])
-    groups.get(groupKey)!.push(t)
-  }
+export default function PromptTemplateList({ templates, onSelect, onChanged, onDeleted }: Props) {
+  // 当前所在的层级：null=包列表（一级），string=某分组内模板网格（二级）
+  const [activeGroup, setActiveGroup] = useState<string | null>(null)
+  // 弹窗中显示的模板 id
+  const [detailId, setDetailId] = useState<number | null>(null)
 
-  // 排序后转数组
-  const sortedGroups = [...groups.entries()].sort((a, b) => {
-    const oa = GROUP_LABELS[a[0]]?.order ?? 99
-    const ob = GROUP_LABELS[b[0]]?.order ?? 99
-    return oa - ob
-  })
-
-  // 折叠状态：默认全部展开
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
-  const toggle = (k: string) => {
-    setCollapsed(prev => {
-      const next = new Set(prev)
-      if (next.has(k)) next.delete(k)
-      else next.add(k)
-      return next
+  // 按分组聚合
+  const groups = useMemo(() => {
+    const m = new Map<string, PromptTemplate[]>()
+    for (const t of templates) {
+      const k = t.moduleKey.split('.')[0]
+      if (!m.has(k)) m.set(k, [])
+      m.get(k)!.push(t)
+    }
+    return [...m.entries()].sort((a, b) => {
+      const oa = GROUP_LABELS[a[0]]?.order ?? 99
+      const ob = GROUP_LABELS[b[0]]?.order ?? 99
+      return oa - ob
     })
-  }
+  }, [templates])
 
-  if (templates.length === 0) {
+  // 弹窗中显示的模板对象
+  const detailTemplate = detailId != null
+    ? templates.find(t => t.id === detailId) ?? null
+    : null
+
+  // ── 一级：提示词包网格 ──
+  if (!activeGroup) {
+    if (templates.length === 0) {
+      return (
+        <div className="p-6 text-center text-text-muted text-sm">
+          当前筛选下没有模板
+        </div>
+      )
+    }
     return (
-      <div className="p-6 text-center text-text-muted text-sm">
-        当前筛选下没有模板
+      <div className="p-4">
+        <div className="mb-3 text-xs text-text-muted">
+          共 {groups.length} 个提示词包 · {templates.length} 条模板 · 点击包进入查看
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
+          {groups.map(([groupKey, items]) => {
+            const meta = GROUP_LABELS[groupKey] || { label: groupKey, emoji: '📁', order: 99, desc: '' }
+            const sysCount = items.filter(t => t.scope === 'system').length
+            return (
+              <button
+                key={groupKey}
+                onClick={() => setActiveGroup(groupKey)}
+                className="group relative p-3 rounded-lg border border-border bg-bg-surface text-left hover:border-accent/50 hover:bg-bg-hover hover:shadow-sm transition-all"
+              >
+                <div className="flex flex-col items-center text-center">
+                  <span className="text-3xl mb-1">{meta.emoji}</span>
+                  <p className="text-sm font-medium text-text-primary truncate w-full">{meta.label}</p>
+                  <p className="text-[10px] text-text-muted line-clamp-2 w-full leading-tight min-h-[2.4em] mt-0.5">
+                    {meta.desc}
+                  </p>
+                  <div className="mt-1 flex items-center gap-1 text-[10px] text-text-muted">
+                    <span className="px-1.5 py-0.5 rounded bg-accent/10 text-accent">{items.length}</span>
+                    {sysCount > 0 && <span className="text-warning/70">★{sysCount}</span>}
+                  </div>
+                </div>
+                <ChevronRight className="absolute top-2 right-2 w-3.5 h-3.5 text-text-muted/40 group-hover:text-accent transition-colors" />
+              </button>
+            )
+          })}
+        </div>
       </div>
     )
   }
 
-  return (
-    <div className="py-2">
-      {sortedGroups.map(([groupKey, items]) => {
-        const meta = GROUP_LABELS[groupKey] || { label: groupKey, emoji: '📁', order: 99 }
-        const isCollapsed = collapsed.has(groupKey)
-        return (
-          <div key={groupKey} className="mb-1">
-            {/* 分组头 */}
-            <button
-              onClick={() => toggle(groupKey)}
-              className="w-full flex items-center gap-1.5 px-3 py-1.5 text-xs text-text-secondary hover:bg-bg-hover"
-            >
-              {isCollapsed
-                ? <ChevronRight className="w-3 h-3" />
-                : <ChevronDown className="w-3 h-3" />}
-              <span className="text-base">{meta.emoji}</span>
-              <span className="font-medium">{meta.label}</span>
-              <span className="ml-auto text-text-muted">{items.length}</span>
-            </button>
-
-            {/* 模板项 */}
-            {!isCollapsed && (
-              <div>
-                {items
-                  .sort((a, b) => (a.scope === 'system' ? -1 : 1) - (b.scope === 'system' ? -1 : 1) || a.id! - b.id!)
-                  .map(t => (
-                    <TemplateRow
-                      key={t.id}
-                      template={t}
-                      selected={t.id === selectedId}
-                      onClick={() => onSelect(t.id!)}
-                    />
-                  ))}
-              </div>
-            )}
-          </div>
-        )
-      })}
-    </div>
-  )
-}
-
-function TemplateRow({
-  template, selected, onClick,
-}: { template: PromptTemplate; selected: boolean; onClick: () => void }) {
-  const subKey = template.moduleKey.split('.').slice(1).join('.')
-  const subLabel = SUB_LABELS[subKey] || subKey
+  // ── 二级：某分组内的模板网格 ──
+  const groupItems = groups.find(([k]) => k === activeGroup)?.[1] ?? []
+  const groupMeta = GROUP_LABELS[activeGroup] || { label: activeGroup, emoji: '📁', order: 99, desc: '' }
 
   return (
-    <button
-      onClick={onClick}
-      className={`w-full flex items-start gap-2 pl-8 pr-3 py-1.5 text-left text-sm border-l-2 transition-colors ${
-        selected
-          ? 'border-accent bg-accent/10 text-text-primary'
-          : 'border-transparent text-text-secondary hover:bg-bg-hover hover:text-text-primary'
-      }`}
-    >
-      {/* scope 图标 */}
-      {template.scope === 'system'
-        ? <Star className="w-3.5 h-3.5 mt-0.5 text-warning flex-shrink-0" />
-        : <User className="w-3.5 h-3.5 mt-0.5 text-info flex-shrink-0" />}
-
-      <div className="flex-1 min-w-0">
-        <div className="truncate flex items-center gap-1.5">
-          <span className="text-xs text-text-muted">[{subLabel}]</span>
-          <span className="truncate">{template.name}</span>
-        </div>
+    <div className="p-4">
+      {/* 返回按钮 + 当前分组标题 */}
+      <div className="flex items-center gap-2 mb-3">
+        <button
+          onClick={() => setActiveGroup(null)}
+          className="flex items-center gap-1 px-2 py-1 text-xs text-text-secondary hover:text-accent border border-border rounded transition-colors"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" /> 返回包列表
+        </button>
+        <span className="text-lg">{groupMeta.emoji}</span>
+        <h3 className="text-sm font-medium text-text-primary">{groupMeta.label}</h3>
+        <span className="text-xs text-text-muted">· {groupItems.length} 条</span>
       </div>
 
-      {template.isDefault && (
-        <span className="text-[10px] px-1.5 py-0.5 rounded bg-warning/15 text-warning flex-shrink-0">
-          默认
-        </span>
+      {groupItems.length === 0 ? (
+        <div className="text-center py-8 text-text-muted text-sm">
+          这个包里没有模板
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
+          {groupItems
+            .sort((a, b) => (a.scope === 'system' ? -1 : 1) - (b.scope === 'system' ? -1 : 1) || (a.id! - b.id!))
+            .map(t => {
+              const subKey = t.moduleKey.split('.').slice(1).join('.')
+              const subLabel = SUB_LABELS[subKey] || subKey
+              return (
+                <button
+                  key={t.id}
+                  onClick={() => { setDetailId(t.id!); onSelect(t.id!) }}
+                  className={`group relative p-2.5 rounded-lg border text-left transition-all ${
+                    detailId === t.id
+                      ? 'border-accent ring-1 ring-accent/40 bg-accent/5'
+                      : 'border-border bg-bg-surface hover:border-accent/40 hover:bg-bg-hover'
+                  }`}
+                >
+                  <div className="flex flex-col items-start text-left">
+                    <div className="flex items-center gap-1 self-stretch mb-1">
+                      {t.scope === 'system'
+                        ? <Star className="w-3 h-3 text-warning flex-shrink-0" />
+                        : <User className="w-3 h-3 text-info flex-shrink-0" />}
+                      <span className="text-[10px] text-text-muted truncate">[{subLabel}]</span>
+                    </div>
+                    <p className="text-xs font-medium text-text-primary line-clamp-2 w-full leading-tight min-h-[2.6em]">
+                      {t.name}
+                    </p>
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {t.isDefault && (
+                        <span className="text-[9px] px-1 py-0.5 rounded bg-warning/15 text-warning">默认</span>
+                      )}
+                      {t.isActive && (
+                        <span className="text-[9px] px-1 py-0.5 rounded bg-success/15 text-success">激活</span>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
+        </div>
       )}
-      {template.isActive && (
-        <span className="text-[10px] px-1.5 py-0.5 rounded bg-success/15 text-success flex-shrink-0">
-          激活
-        </span>
+
+      {/* ── 详情弹窗：独立滚动 ── */}
+      {detailTemplate && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+          onClick={() => setDetailId(null)}
+        >
+          <div
+            className="relative bg-bg-base border border-border rounded-lg shadow-xl w-full max-w-4xl max-h-[85vh] flex flex-col"
+            onClick={e => e.stopPropagation()}
+          >
+            {/* 弹窗头：标题 + 关闭 */}
+            <div className="flex items-center justify-between px-4 py-2 border-b border-border shrink-0">
+              <span className="flex items-center gap-1.5 text-sm font-medium text-text-primary">
+                <FileText className="w-4 h-4 text-accent" />
+                {detailTemplate.name}
+                <span className="text-xs text-text-muted font-normal ml-1">[{detailTemplate.moduleKey}]</span>
+              </span>
+              <button
+                onClick={() => setDetailId(null)}
+                className="p-1 text-text-muted hover:text-text-primary rounded transition-colors"
+                title="关闭"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            {/* 弹窗内容：独立滚动 */}
+            <div className="overflow-y-auto p-4">
+              <PromptTemplateEditor
+                template={detailTemplate}
+                onChanged={onChanged ?? (() => {})}
+                onDeleted={() => { setDetailId(null); onDeleted?.() }}
+              />
+            </div>
+          </div>
+        </div>
       )}
-    </button>
+    </div>
   )
 }


### PR DESCRIPTION
## 改动说明 / What & Why

<!-- 这个 PR 做了什么,为什么 -->
提示词库列表重写为两级网格布局（提示词包 → 提示词，每行 6 个）
点击提示词包进入该包内部提示词列表
点击提示词打开详情弹窗（含内置滚动条 max-h-[85vh] overflow-y-auto）
主题包切换、范围筛选、导入导出等原有功能保留
## 关联 Issue / Related issue

<!-- Closes #N -->

## 自检清单 / Checklist

- [ ] 已读 `CLAUDE.md`,改动遵循三注册表铁律(未直接调 db / 未手挑上下文 / 未手写表清单)
- [ ] `npm run ci` 本地全绿(check:required-tables / check:ai-manual / check:architecture / tsc / test / build)
- [ ] 若改了 DB schema:已写迁移测试 + 真实数据实测
- [ ] 若加了表/字段/上下文源/AI 动作:已同步对应注册表
- [ ] 若改了 AI 行为:已跑 `npm run gen:ai-manual` 重新生成说明书
- [ ] 修 bug 的:已有一条会失败→变绿的反例测试
