### PR TITLE
fix(ci): upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,14 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Generate current star history
         run: node scripts/generate-star-history.mjs /tmp/storyforge-star-history.svg

--- a/.github/workflows/traffic-archive.yml
+++ b/.github/workflows/traffic-archive.yml
@@ -14,7 +14,7 @@ jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Archive traffic data
         env:

--- a/tests/regression/R-HARNESS86-story-arc-main-path-eval.test.ts
+++ b/tests/regression/R-HARNESS86-story-arc-main-path-eval.test.ts
@@ -43,6 +43,23 @@ import type { AIConfig } from '../../src/lib/types'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
+async function waitForUi(assertion: () => void, timeoutMs = 5_000): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      assertion()
+      return
+    } catch (cause) {
+      lastError = cause
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 10))
+      })
+    }
+  }
+  throw lastError
+}
+
 const generator: H86ModelIdentityV1 = {
   provider: 'agnes',
   model: 'agnes-2.5-flash',
@@ -481,7 +498,9 @@ describe.sequential('R-HARNESS86 · 真实故事线主路径配对评测', { tim
     try {
       await act(async () => {
         root.render(createElement(DialogProvider, null, createElement(H86HumanReviewPanel, { checkpoint })))
-        await new Promise(resolve => setTimeout(resolve, 10))
+      })
+      await waitForUi(() => {
+        expect(host.querySelector('[data-testid="h86-human-current-case"]')).not.toBeNull()
       })
       const section = host.querySelector('[data-testid="h86-human-review"]')
       expect(section?.textContent).toContain('候选 A')
@@ -492,7 +511,9 @@ describe.sequential('R-HARNESS86 · 真实故事线主路径配对评测', { tim
 
       await act(async () => {
         section?.querySelector<HTMLButtonElement>('[data-testid="h86-save-human-case"]')?.click()
-        await new Promise(resolve => setTimeout(resolve, 10))
+      })
+      await waitForUi(() => {
+        expect(host.querySelector('[data-testid="h86-human-progress"]')?.textContent).toBe('1/6')
       })
       expect(host.querySelector('[data-testid="h86-human-progress"]')?.textContent).toBe('1/6')
       expect((await loadH86HumanReviewV1())?.items.filter(item => item.reviewA != null)).toHaveLength(1)


### PR DESCRIPTION
## What changed

- Upgrade `actions/checkout` from v4 to v7 in CI, release, star-history, and traffic workflows.
- Upgrade `actions/setup-node` from v4 to v7 wherever Node is installed.
- Standardize CI, release, and star-history automation on Node.js 24.
- Replace H86 blind-review UI test fixed 10 ms sleeps with bounded condition polling so IndexedDB/React timing cannot intermittently fail CI.

## Why

GitHub now forces JavaScript actions that still target Node.js 20 to run on Node.js 24 and emits a deprecation warning. Updating to the current official Action majors removes that compatibility path.

The previous #68 failure was unrelated to the Actions upgrade: the H86 test observed `0/6` before its asynchronous persistence completed. The test now waits for the actual restored case and persisted progress instead of assuming completion after 10 ms.

## Impact

This changes build automation and test synchronization only. It does not alter StoryForge browser behavior, IndexedDB schemas, user data, the memory workspace, model calls, or token usage.

## Validation

- Official latest releases verified: `actions/checkout v7.0.1`, `actions/setup-node v7.0.0`.
- Parsed all four workflow YAML files and confirmed no remaining checkout/setup-node v4-v6 or Node 20/22 workflow runtimes.
- H86 regression file passed 6 consecutive targeted runs.
- `npm run check:release-metadata -- v3.9.1`.
- `npm run ci`: 435 test files / 2043 tests; coverage 83.56% statements/lines, 73.71% branches, 81.61% functions; architecture, dependencies, TypeScript, build, PWA, and bundle-size gates passed.
- `PLAYWRIGHT_PORT=4194 npm run ci:e2e`: Chromium 53/53, including real local memory-workspace reconciliation.
- `git diff --check`.