### PR TITLE
fix(db): prevent PrematureCommitError in populated projects

### DIFF
--- a/src/lib/agent/conversations.ts
+++ b/src/lib/agent/conversations.ts
@@ -68,11 +68,10 @@ export async function readAgentEvents(conversationId: number, scope?: WorkspaceS
     .where('conversationId')
     .equals(conversationId)
     .sortBy('sequence')
-  const owned: AgentEvent[] = []
-  for (const event of events) {
-    if (await assertRecordInScope(resolved, 'agentEvents', event, { owner: 'work' })) owned.push(event)
-  }
-  return owned
+  const ownership = await Promise.all(events.map(event => (
+    assertRecordInScope(resolved, 'agentEvents', event, { owner: 'work' })
+  )))
+  return events.filter((_, index) => ownership[index])
 }
 
 export async function appendAgentEvent(input: {
@@ -95,10 +94,13 @@ export async function appendAgentEvent(input: {
       .where('conversationId')
       .equals(input.conversationId)
       .toArray()
-    const existing: AgentEvent[] = []
-    for (const event of candidates) {
-      if (await assertRecordInScope(scope, 'agentEvents', event, { owner: 'work' })) existing.push(event)
-    }
+    // A long conversation can contain hundreds of direct-owner rows. Validate
+    // them under one global Promise.all so the surrounding IndexedDB
+    // transaction cannot auto-commit between synchronous ownership checks.
+    const ownership = await Promise.all(candidates.map(event => (
+      assertRecordInScope(scope, 'agentEvents', event, { owner: 'work' })
+    )))
+    const existing = candidates.filter((_, index) => ownership[index])
     const sequence = existing.reduce((max, event) => Math.max(max, event.sequence), 0) + 1
     const createdAt = Date.now()
     const event = stampNewRecord(scope, 'agentEvents', {

--- a/src/lib/world-engine/scope.ts
+++ b/src/lib/world-engine/scope.ts
@@ -243,11 +243,15 @@ export async function readOwnedRows<T = Record<string, unknown>>(
   const rows = spec.owner === 'project' || spec.owner === 'transient'
     ? await spec.table.where('projectId').equals(scope.projectId).toArray()
     : await spec.table.toArray()
-  const owned: T[] = []
-  for (const row of rows as Record<string, unknown>[]) {
-    if (await assertRecordInScope(scope, tableName, row, options)) owned.push(row as T)
-  }
-  return owned
+  // Keep this to one awaited Promise while callers may be inside a Dexie
+  // transaction. Most direct-owner checks resolve without issuing another IDB
+  // request; awaiting them one by one can let a browser auto-commit a large
+  // transaction before the caller performs its write.
+  const records = rows as Record<string, unknown>[]
+  const ownership = await Promise.all(records.map(row => (
+    assertRecordInScope(scope, tableName, row, options)
+  )))
+  return records.filter((_, index) => ownership[index]) as T[]
 }
 
 /** Stamp a new row from trusted scope. Existing owner ids must agree or the write fails closed. */

--- a/tests/regression/R-DEXIE-PREMATURE-COMMIT.test.ts
+++ b/tests/regression/R-DEXIE-PREMATURE-COMMIT.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { appendAgentEvent, getOrCreateAgentConversation } from '../../src/lib/agent/conversations'
+import {
+  appendAgentRunEventV1,
+  createAgentRunV1,
+  readAgentRunV1,
+} from '../../src/lib/agent/run/event-store'
 import { db } from '../../src/lib/db/schema'
+import { deriveStrictExportProjectJSON } from '../../src/lib/export/registry-export'
+import { deriveImportProjectJSON } from '../../src/lib/export/registry-import'
 import type { AgentEvent, Character, WorkspaceScope } from '../../src/lib/types'
 import { readOwnedRows, scopeTransactionTables } from '../../src/lib/world-engine/scope'
 
@@ -13,6 +20,8 @@ async function createWorkspace(): Promise<WorkspaceScope> {
     status: 'drafting',
     description: '',
     targetWordCount: 100_000,
+    worldCode: 'dexie-transaction-longevity',
+    worldVersion: 1,
     createdAt: now,
     updatedAt: now,
   } as any) as number
@@ -44,7 +53,7 @@ async function createWorkspace(): Promise<WorkspaceScope> {
   return { projectId, worldId, workId }
 }
 
-describe.sequential('R-DEXIE-PREMATURE-COMMIT · large scoped reads keep write transactions alive', () => {
+describe.sequential('R-DEXIE-PREMATURE-COMMIT · long reads and ledgers keep write transactions alive', () => {
   beforeEach(async () => {
     await db.delete()
     await db.open()
@@ -117,4 +126,121 @@ describe.sequential('R-DEXIE-PREMATURE-COMMIT · large scoped reads keep write t
     expect(appended.sequence).toBe(161)
     expect(await db.agentEvents.where('conversationId').equals(conversation.id!).count()).toBe(161)
   })
+
+  it('round-trips a 167-event durable ledger and appends afterward', async () => {
+    const scope = await createWorkspace()
+    const now = Date.now()
+    const worldGroupId = await db.worldGroups.add({
+      projectId: scope.projectId,
+      worldId: scope.worldId,
+      name: '主世界',
+      order: 0,
+      createdAt: now,
+      updatedAt: now,
+    }) as number
+    const outlineNodeId = await db.outlineNodes.add({
+      projectId: scope.projectId,
+      worldId: null,
+      workId: scope.workId,
+      worldGroupId,
+      parentId: null,
+      type: 'volume',
+      title: '第一卷',
+      summary: '',
+      order: 0,
+      createdAt: now,
+      updatedAt: now,
+    }) as number
+    let snapshot = await createAgentRunV1({
+      scope,
+      worldGroupId,
+      contract: {
+        version: 1,
+        objective: '验证大账本导入后仍可继续运行',
+        workflowKind: 'long-running-resumable',
+        scope: {
+          projectId: scope.projectId,
+          worldGroupId,
+          outlineNodeIds: [outlineNodeId],
+        },
+        permissions: {
+          contextSourceKeys: ['worldview', 'storyCore'],
+          writeTargets: [{ table: 'outlineNodes', fields: ['summary'], mode: 'candidate-only' }],
+        },
+        budget: {
+          maxModelCalls: 3,
+          maxToolCalls: 300,
+          maxInputTokens: 8_000,
+          maxOutputTokens: 2_000,
+          maxAttemptsPerStep: 2,
+        },
+        acceptance: [{ id: 'outline.output', kind: 'output-present', required: true }],
+        verificationPlan: [{
+          id: 'outline.terminal',
+          kind: 'terminal',
+          verifier: 'terminal-v1',
+          criterionIds: ['outline.output'],
+        }],
+        failurePolicy: {
+          onProtocolError: 'fail',
+          onVerificationFailure: 'fail',
+          onStaleInput: 'pause-for-author',
+        },
+      },
+    })
+    snapshot = await appendAgentRunEventV1({
+      scope,
+      runId: snapshot.run.id,
+      type: 'step.scheduled',
+      payload: { stepId: 'outline.generate' },
+    })
+    snapshot = await appendAgentRunEventV1({
+      scope,
+      runId: snapshot.run.id,
+      type: 'step.started',
+      payload: { stepId: 'outline.generate', attempt: 1 },
+    })
+    for (let index = 0; index < 163; index += 1) {
+      snapshot = await appendAgentRunEventV1({
+        scope,
+        runId: snapshot.run.id,
+        type: 'tool.called',
+        payload: {
+          stepId: 'outline.generate',
+          attempt: 1,
+          toolName: 'read_context',
+          callHash: index.toString(16).padStart(64, '0'),
+        },
+      })
+    }
+    expect(snapshot.events).toHaveLength(167)
+
+    const exported = await deriveStrictExportProjectJSON(scope.projectId)
+    const importedProjectId = await deriveImportProjectJSON(exported)
+    const importedProject = await db.projects.get(importedProjectId)
+    const importedRun = await db.agentRuns.where('projectId').equals(importedProjectId).first()
+    expect(importedProject?.activeWorldId).toBeTypeOf('number')
+    expect(importedProject?.activeWorkId).toBeTypeOf('number')
+    expect(importedRun?.id).toBeTypeOf('number')
+
+    const importedScope: WorkspaceScope = {
+      projectId: importedProjectId,
+      worldId: importedProject!.activeWorldId!,
+      workId: importedProject!.activeWorkId!,
+    }
+    const restored = await readAgentRunV1(importedScope, importedRun!.id!)
+    expect(restored.events).toHaveLength(167)
+
+    const appended = await appendAgentRunEventV1({
+      scope: importedScope,
+      runId: importedRun!.id!,
+      type: 'context.assembled',
+      payload: {
+        stepId: 'outline.generate',
+        attempt: 1,
+        manifestHash: 'f'.repeat(64),
+      },
+    })
+    expect(appended.events).toHaveLength(168)
+  }, 20_000)
 })

--- a/tests/regression/R-DEXIE-PREMATURE-COMMIT.test.ts
+++ b/tests/regression/R-DEXIE-PREMATURE-COMMIT.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { appendAgentEvent, getOrCreateAgentConversation } from '../../src/lib/agent/conversations'
+import { db } from '../../src/lib/db/schema'
+import type { AgentEvent, Character, WorkspaceScope } from '../../src/lib/types'
+import { readOwnedRows, scopeTransactionTables } from '../../src/lib/world-engine/scope'
+
+async function createWorkspace(): Promise<WorkspaceScope> {
+  const now = Date.now()
+  const projectId = await db.projects.add({
+    name: 'Dexie transaction longevity',
+    genre: 'fantasy',
+    genres: ['fantasy'],
+    status: 'drafting',
+    description: '',
+    targetWordCount: 100_000,
+    createdAt: now,
+    updatedAt: now,
+  } as any) as number
+  const worldId = await db.worlds.add({
+    projectId,
+    code: 'dexie-transaction-longevity',
+    name: '事务世界',
+    description: '',
+    currentVersion: 1,
+    createdAt: now,
+    updatedAt: now,
+  }) as number
+  const workId = await db.works.add({
+    projectId,
+    worldId,
+    title: '事务作品',
+    description: '',
+    genres: ['fantasy'],
+    status: 'drafting',
+    targetWordCount: 100_000,
+    createdAt: now,
+    updatedAt: now,
+  }) as number
+  await db.projects.update(projectId, {
+    activeWorldId: worldId,
+    activeWorkId: workId,
+    ownershipSchemaVersion: 1,
+  })
+  return { projectId, worldId, workId }
+}
+
+describe.sequential('R-DEXIE-PREMATURE-COMMIT · large scoped reads keep write transactions alive', () => {
+  beforeEach(async () => {
+    await db.delete()
+    await db.open()
+  })
+
+  afterEach(() => db.close())
+
+  it('filters a populated World collection before writing in the same transaction', async () => {
+    const scope = await createWorkspace()
+    const now = Date.now()
+    const characters = Array.from({ length: 96 }, (_, index) => ({
+      projectId: scope.projectId,
+      worldId: scope.worldId,
+      name: `存量角色 ${index + 1}`,
+      role: 'minor',
+      roleWeight: 'secondary',
+      moralAxis: 'neutral',
+      orderAxis: 'neutral',
+      homeWorldGroupId: null,
+      isCrossWorld: false,
+      createdAt: now,
+      updatedAt: now,
+    })) as Character[]
+    await db.characters.bulkAdd(characters)
+
+    await db.transaction('rw', scopeTransactionTables(db.characters), async () => {
+      const owned = await readOwnedRows<Character>(scope, 'characters', { owner: 'world' })
+      expect(owned).toHaveLength(96)
+      await db.characters.add({
+        ...characters[0],
+        id: undefined,
+        name: '事务末尾新增角色',
+      })
+    })
+
+    expect(await db.characters.where('projectId').equals(scope.projectId).count()).toBe(97)
+  })
+
+  it('appends the next sequence after a long Agent conversation', async () => {
+    const scope = await createWorkspace()
+    const conversation = await getOrCreateAgentConversation({
+      projectId: scope.projectId,
+      worldGroupId: null,
+      scope,
+    })
+    const now = Date.now()
+    const events = Array.from({ length: 160 }, (_, index) => ({
+      projectId: scope.projectId,
+      workId: scope.workId,
+      conversationId: conversation.id!,
+      durableRunId: null,
+      sequence: index + 1,
+      kind: 'message' as const,
+      role: 'assistant' as const,
+      content: `历史事件 ${index + 1}`,
+      payload: '{}',
+      createdAt: now + index,
+    })) satisfies AgentEvent[]
+    await db.agentEvents.bulkAdd(events)
+
+    const appended = await appendAgentEvent({
+      projectId: scope.projectId,
+      scope,
+      conversationId: conversation.id!,
+      kind: 'message',
+      role: 'user',
+      content: '继续使用 AI',
+    })
+
+    expect(appended.sequence).toBe(161)
+    expect(await db.agentEvents.where('conversationId').equals(conversation.id!).count()).toBe(161)
+  })
+})


### PR DESCRIPTION
## Summary

- batch scope ownership checks so IndexedDB transactions do not become idle before their final write
- cover populated World collections, long Agent conversations, and a strict 167-event durable-ledger round-trip
- keep the change isolated from the in-progress world-engine review branch

## External report and reproduction

An external user on v3.9.1+local reported that AI usage eventually failed with Dexie PrematureCommitError and only rebuilding a project temporarily restored it.

Using an isolated browser database and the real durable character adoption path:

- before the fix: 33 rounds succeeded and round 34 failed with the reported PrematureCommitError
- after the fix: 50 of 50 rounds succeeded in the same growing project

Rebuilding only reduced the number of scoped rows, which explains why it temporarily hid this transaction-idle bug.

A follow-up report attributed the failure to every async Dexie callback/helper and recommended removing async or waitFor guards. Current code and Dexie documentation do not support that broader conclusion:

- current agent hashes use WebCrypto and are asynchronous
- transaction-time WebCrypto and portable-ledger operations are already guarded by Dexie.waitFor
- Dexie officially supports async transaction callbacks and native await; waitFor is specifically the mechanism for keeping a transaction active around non-IndexedDB work

I therefore did not remove those guards. Instead, the new regression creates 167 valid run events, performs strict export and import, verifies the imported ledger, and successfully appends event 168. The same path also passed in real Chromium.

Dexie references: https://dexie.org/docs/Dexie/Dexie.transaction%28%29 and https://dexie.org/docs/Dexie/Dexie.waitFor%28%29

## Validation

- npm test -- --run tests/regression/R-DEXIE-PREMATURE-COMMIT.test.ts — 3 tests passed, including 167 -> 168 ledger round-trip
- npx tsc --noEmit
- npm run check:architecture
- npm run check:required-tables
- npm run check:ai-manual
- npm run check:dependencies
- npm run lint
- npm run build
- npm run check:bundle-size
- git diff --check
- full coverage run: 436 files and 2051 tests passed; two unrelated heavy tests hit their existing 5 s and 20 s timeouts under full-suite load, then both files passed in isolation (16 tests)

Full npm run ci currently stops at check:project-metrics because the latest clean origin/main reports existing MASTER-BLUEPRINT metric drift. This PR does not regenerate that unrelated document.

## Review timing

This PR is intentionally safe to leave open until the world-engine flow review finishes. At that point it can be:

1. merged if the affected transaction pattern still exists;
2. reduced to the regression tests if the review replaces the implementation; or
3. closed if the new architecture makes both the implementation and tests obsolete.