### PR TITLE
fix(ai): prevent maximum update depth during streamed output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2634,9 +2634,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2656,9 +2653,6 @@
       "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2680,9 +2674,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2703,9 +2694,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2725,9 +2713,6 @@
       "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3030,9 +3015,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3047,9 +3029,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3064,9 +3043,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3081,9 +3057,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3098,9 +3071,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3115,9 +3085,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3132,9 +3099,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3149,9 +3113,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3166,9 +3127,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3183,9 +3141,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3200,9 +3155,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3217,9 +3169,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3234,9 +3183,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/components/editor/ChapterEditor.tsx
+++ b/src/components/editor/ChapterEditor.tsx
@@ -266,7 +266,6 @@ interface PendingChapterGeneration {
   operation: ChapterGenerationOperation
   category: ChapterGenerationCategory
   prepared: PreparedGenerationNode
-  backgroundMemoryIds: number[]
   assembled: Awaited<ReturnType<typeof assembleContext>>
   generationBinding: AgentSkillExecutionBindingV2
   informationBoundary: InformationBoundaryManifestV1
@@ -377,6 +376,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
   const [pendingGeneration, setPendingGeneration] = useState<PendingChapterGeneration | null>(null)
   const [proseCandidate, setProseCandidate] = useState<ProseGenerationCandidateV1 | null>(null)
   const [proseGenerationError, setProseGenerationError] = useState('')
+  const [preparingGeneration, setPreparingGeneration] = useState(false)
   const [planReconciliationCurrent, setPlanReconciliationCurrent] = useState(false)
   const [organizationRun, setOrganizationRun] = useState<ChapterOrganizationRun | null>(null)
   const [organizationCurrent, setOrganizationCurrent] = useState(false)
@@ -1150,8 +1150,8 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
     }
   }
 
-  const prepareContinuityBeforeGeneration = async (): Promise<number[]> => {
-    if (!currentChapter?.id) return []
+  const prepareContinuityBeforeGeneration = async (): Promise<void> => {
+    if (!currentChapter?.id) return
     const snapshot = await prepareContinuityContext({
       projectId: project.id!,
       chapterId: currentChapter.id,
@@ -1164,16 +1164,6 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
       // 直接前驱优先且同步补建；失败仍由真实 tail 保底。
       await rebuildChapterMemoryById(predecessorId)
     }
-    return snapshot.memoryRebuildCandidateIds
-      .filter(id => id !== predecessorId)
-      .slice(-4)
-  }
-
-  const scheduleRecentMemoryRebuild = (chapterIds: number[]) => {
-    if (!chapterIds.length) return
-    void (async () => {
-      for (const chapterId of chapterIds) await rebuildChapterMemoryById(chapterId)
-    })()
   }
 
   const buildFullWorldCtx = async (
@@ -1444,7 +1434,6 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
     operation: ChapterGenerationOperation,
     category: ChapterGenerationCategory,
     prepared: PreparedGenerationNode,
-    backgroundMemoryIds: number[],
     messages?: ChatMessage[],
     assembled?: Awaited<ReturnType<typeof assembleContext>>,
     generationBinding?: AgentSkillExecutionBindingV2,
@@ -1453,6 +1442,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
   ) => {
     if (!informationBoundary || !generationBinding || !contentRevision) {
       setProseGenerationError('正文生成缺少 Skill 或信息边界快照，已阻止模型调用。')
+      setPreparingGeneration(false)
       return
     }
     ai.setOperation(operation)
@@ -1469,15 +1459,16 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
       contentRevision,
     }).catch(error => {
       console.error('[ChapterEditor] 生成节点执行失败:', error)
+      setProseGenerationError(error instanceof Error ? error.message : '正文生成失败。')
+    }).finally(() => {
+      setPreparingGeneration(false)
     })
-    scheduleRecentMemoryRebuild(backgroundMemoryIds)
   }
 
   const prepareOrRunChapterGeneration = (
     operation: ChapterGenerationOperation,
     category: ChapterGenerationCategory,
     messages: ChatMessage[],
-    backgroundMemoryIds: number[],
     assembled: Awaited<ReturnType<typeof assembleContext>>,
     generationBinding: AgentSkillExecutionBindingV2,
     informationBoundary: InformationBoundaryManifestV1,
@@ -1491,12 +1482,12 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
         operation,
         category,
         prepared,
-        backgroundMemoryIds,
         assembled,
         generationBinding,
         informationBoundary,
         contentRevision,
       })
+      setPreparingGeneration(false)
       return
     }
     setPendingGeneration(null)
@@ -1504,7 +1495,6 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
       operation,
       category,
       prepared,
-      backgroundMemoryIds,
       undefined,
       assembled,
       generationBinding,
@@ -1514,131 +1504,133 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
   }
 
   const handleGenerate = async () => {
-    if (!outlineNode) return
+    if (!outlineNode || preparingGeneration || ai.isStreaming) return
+    setPreparingGeneration(true)
     setProseGenerationError('')
     try {
       await flushPendingEditsV1()
+      await persistCurrentEditorContent()
+      await prepareContinuityBeforeGeneration()
+      const scope = await resolveScopeLike(project.id!)
+      const contentRevision = await captureWorkspaceContentRevisionV1({
+        scope,
+        worldGroupId: chapterWorldGroupId ?? null,
+      })
+      const {
+        text: fullCtx,
+        segments: assembledSegments,
+        assembled,
+        generationBinding,
+        characterContext,
+        worldRulesContext,
+        continuity,
+        continuityBudgetTokens,
+      } = await buildFullWorldCtx('generate', 'write')
+      await assertWorkspaceContentRevisionFreshV1(contentRevision, {
+        scope,
+        worldGroupId: chapterWorldGroupId ?? null,
+      })
+      const informationBoundary = await buildChapterInformationBoundaryV1({
+        scope: await resolveScopeLike(project.id!),
+        chapterId: currentChapter?.id ?? null,
+        outlineNodeId: outlineNode.id!,
+        worldGroupId: chapterWorldGroupId ?? null,
+        perspectiveCharacterId,
+      })
+      const messages = buildChapterContentPrompt(
+        outlineNode.title,
+        outlineNode.summary,
+        fullCtx,
+        characterContext,
+        continuity.previousTail,
+        worldRulesContext,
+        [buildInformationBoundaryInstructionV1(informationBoundary), customInstruction.trim()]
+          .filter(Boolean)
+          .join('\n'),
+        { continuity, continuityBudgetTokens },
+      )
+
+      // Phase 21.3: 计算上下文预算
+      const segments = analyzeContextSegments([
+        { label: 'System Prompt', content: messages.find(m => m.role === 'system')?.content || '', layer: 'L0' },
+        { label: '章节大纲', content: outlineNode.summary || '', layer: 'L1' },
+        ...assembledSegments,
+        { label: 'User Prompt', content: messages.find(m => m.role === 'user')?.content || '', layer: 'L1' },
+      ])
+      setContextBudget(calculateBudget(aiConfig.provider, aiConfig.model, segments, aiConfig.contextWindow))
+
+      prepareOrRunChapterGeneration(
+        'generate',
+        'chapter.content',
+        messages,
+        assembled,
+        generationBinding,
+        informationBoundary,
+        contentRevision,
+      )
     } catch (error) {
-      setProseGenerationError(error instanceof Error ? error.message : '作者编辑保存失败，已阻止正式生成。')
-      return
+      console.error('[ChapterEditor] 正文生成准备失败:', error)
+      setProseGenerationError(error instanceof Error ? error.message : '正文生成准备失败。')
+      setPreparingGeneration(false)
     }
-    await persistCurrentEditorContent()
-    const backgroundMemoryIds = await prepareContinuityBeforeGeneration()
-    const scope = await resolveScopeLike(project.id!)
-    const contentRevision = await captureWorkspaceContentRevisionV1({
-      scope,
-      worldGroupId: chapterWorldGroupId ?? null,
-    })
-    const {
-      text: fullCtx,
-      segments: assembledSegments,
-      assembled,
-      generationBinding,
-      characterContext,
-      worldRulesContext,
-      continuity,
-      continuityBudgetTokens,
-    } = await buildFullWorldCtx('generate', 'write')
-    await assertWorkspaceContentRevisionFreshV1(contentRevision, {
-      scope,
-      worldGroupId: chapterWorldGroupId ?? null,
-    })
-    const informationBoundary = await buildChapterInformationBoundaryV1({
-      scope: await resolveScopeLike(project.id!),
-      chapterId: currentChapter?.id ?? null,
-      outlineNodeId: outlineNode.id!,
-      worldGroupId: chapterWorldGroupId ?? null,
-      perspectiveCharacterId,
-    })
-    const messages = buildChapterContentPrompt(
-      outlineNode.title,
-      outlineNode.summary,
-      fullCtx,
-      characterContext,
-      continuity.previousTail,
-      worldRulesContext,
-      [buildInformationBoundaryInstructionV1(informationBoundary), customInstruction.trim()]
-        .filter(Boolean)
-        .join('\n'),
-      { continuity, continuityBudgetTokens },
-    )
-
-    // Phase 21.3: 计算上下文预算
-    const segments = analyzeContextSegments([
-      { label: 'System Prompt', content: messages.find(m => m.role === 'system')?.content || '', layer: 'L0' },
-      { label: '章节大纲', content: outlineNode.summary || '', layer: 'L1' },
-      ...assembledSegments,
-      { label: 'User Prompt', content: messages.find(m => m.role === 'user')?.content || '', layer: 'L1' },
-    ])
-    setContextBudget(calculateBudget(aiConfig.provider, aiConfig.model, segments, aiConfig.contextWindow))
-
-    prepareOrRunChapterGeneration(
-      'generate',
-      'chapter.content',
-      messages,
-      backgroundMemoryIds,
-      assembled,
-      generationBinding,
-      informationBoundary,
-      contentRevision,
-    )
   }
 
   const handleContinue = async () => {
-    if (!plainText || !outlineNode) return
+    if (!plainText || !outlineNode || preparingGeneration || ai.isStreaming) return
+    setPreparingGeneration(true)
     setProseGenerationError('')
     try {
       await flushPendingEditsV1()
+      await persistCurrentEditorContent()
+      await prepareContinuityBeforeGeneration()
+      const scope = await resolveScopeLike(project.id!)
+      const contentRevision = await captureWorkspaceContentRevisionV1({
+        scope,
+        worldGroupId: chapterWorldGroupId ?? null,
+      })
+      const {
+        text: fullCtx,
+        assembled,
+        generationBinding,
+        characterContext,
+        continuity,
+        continuityBudgetTokens,
+      } = await buildFullWorldCtx('continue', 'write')
+      await assertWorkspaceContentRevisionFreshV1(contentRevision, {
+        scope,
+        worldGroupId: chapterWorldGroupId ?? null,
+      })
+      const informationBoundary = await buildChapterInformationBoundaryV1({
+        scope: await resolveScopeLike(project.id!),
+        chapterId: currentChapter?.id ?? null,
+        outlineNodeId: outlineNode.id!,
+        worldGroupId: chapterWorldGroupId ?? null,
+        perspectiveCharacterId,
+      })
+      const ctxWithChars = characterContext ? `${fullCtx}\n\n【角色设定】\n${characterContext}` : fullCtx
+      const messages = buildContinuePrompt(
+        plainText,
+        outlineNode.summary,
+        ctxWithChars,
+        [buildInformationBoundaryInstructionV1(informationBoundary), customInstruction.trim()]
+          .filter(Boolean)
+          .join('\n'),
+        { continuity, continuityBudgetTokens },
+      )
+      prepareOrRunChapterGeneration(
+        'continue',
+        'chapter.continue',
+        messages,
+        assembled,
+        generationBinding,
+        informationBoundary,
+        contentRevision,
+      )
     } catch (error) {
-      setProseGenerationError(error instanceof Error ? error.message : '作者编辑保存失败，已阻止正式续写。')
-      return
+      console.error('[ChapterEditor] 正文续写准备失败:', error)
+      setProseGenerationError(error instanceof Error ? error.message : '正文续写准备失败。')
+      setPreparingGeneration(false)
     }
-    await persistCurrentEditorContent()
-    const backgroundMemoryIds = await prepareContinuityBeforeGeneration()
-    const scope = await resolveScopeLike(project.id!)
-    const contentRevision = await captureWorkspaceContentRevisionV1({
-      scope,
-      worldGroupId: chapterWorldGroupId ?? null,
-    })
-    const {
-      text: fullCtx,
-      assembled,
-      generationBinding,
-      characterContext,
-      continuity,
-      continuityBudgetTokens,
-    } = await buildFullWorldCtx('continue', 'write')
-    await assertWorkspaceContentRevisionFreshV1(contentRevision, {
-      scope,
-      worldGroupId: chapterWorldGroupId ?? null,
-    })
-    const informationBoundary = await buildChapterInformationBoundaryV1({
-      scope: await resolveScopeLike(project.id!),
-      chapterId: currentChapter?.id ?? null,
-      outlineNodeId: outlineNode.id!,
-      worldGroupId: chapterWorldGroupId ?? null,
-      perspectiveCharacterId,
-    })
-    const ctxWithChars = characterContext ? `${fullCtx}\n\n【角色设定】\n${characterContext}` : fullCtx
-    const messages = buildContinuePrompt(
-      plainText,
-      outlineNode.summary,
-      ctxWithChars,
-      [buildInformationBoundaryInstructionV1(informationBoundary), customInstruction.trim()]
-        .filter(Boolean)
-        .join('\n'),
-      { continuity, continuityBudgetTokens },
-    )
-    prepareOrRunChapterGeneration(
-      'continue',
-      'chapter.continue',
-      messages,
-      backgroundMemoryIds,
-      assembled,
-      generationBinding,
-      informationBoundary,
-      contentRevision,
-    )
   }
 
   const handlePolish = () => {
@@ -3366,6 +3358,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
       {compareSourceHtml == null && (
         <ChapterEditorToolbar
           isStreaming={ai.isStreaming}
+          isPreparingGeneration={preparingGeneration}
           hasText={!!plainText}
           organizingChapter={organizingChapter}
           hasOrganizationCandidate={Boolean(
@@ -3641,11 +3634,11 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
             onConfirm={messages => {
               const pending = pendingGeneration
               setPendingGeneration(null)
+              setPreparingGeneration(true)
               runPreparedChapterGeneration(
                 pending.operation,
                 pending.category,
                 pending.prepared,
-                pending.backgroundMemoryIds,
                 messages,
                 pending.assembled,
                 pending.generationBinding,
@@ -3659,7 +3652,7 @@ export default function ChapterEditor({ project, outlineNodeId }: Props) {
 
       {proseGenerationError && (
         <div className="mb-3 rounded-lg border border-error/30 bg-error/5 px-3 py-2 text-xs text-error">
-          正文候选未通过质量门：{proseGenerationError}
+          正文生成未完成：{proseGenerationError}
         </div>
       )}
 

--- a/src/components/editor/ChapterEditorToolbar.tsx
+++ b/src/components/editor/ChapterEditorToolbar.tsx
@@ -38,6 +38,7 @@ const IMPACT_REVIEW_ACTION_LABELS: Record<string, string> = {
 
 interface Props {
   isStreaming: boolean
+  isPreparingGeneration: boolean
   hasText: boolean
   organizingChapter: boolean
   hasOrganizationCandidate: boolean
@@ -123,6 +124,7 @@ interface Props {
 
 export default function ChapterEditorToolbar({
   isStreaming,
+  isPreparingGeneration,
   hasText,
   organizingChapter,
   hasOrganizationCandidate,
@@ -213,11 +215,13 @@ export default function ChapterEditorToolbar({
     ?? impactDownstreamSchedule?.items.find(item => item.status === 'blocked')
   return (
     <div className="flex flex-wrap gap-2 border-t border-border/60 bg-bg-surface/35 px-6 py-3">
-      <button onClick={onGenerate} disabled={isStreaming}
-        className="rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/20 disabled:opacity-50 transition-colors">
-        ✨ 生成正文
+      <button onClick={onGenerate} disabled={isStreaming || isPreparingGeneration}
+        className="flex items-center gap-1 rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/20 disabled:opacity-50 transition-colors">
+        {isPreparingGeneration
+          ? <><Loader2 className="h-3 w-3 animate-spin" />准备中...</>
+          : '✨ 生成正文'}
       </button>
-      <button onClick={onContinue} disabled={isStreaming || !hasText}
+      <button onClick={onContinue} disabled={isStreaming || isPreparingGeneration || !hasText}
         className="rounded-md border border-border bg-bg-elevated px-3 py-1.5 text-xs text-text-secondary hover:text-text-primary disabled:opacity-50 transition-colors">
         📝 续写
       </button>

--- a/src/components/outline/ScenePanel.tsx
+++ b/src/components/outline/ScenePanel.tsx
@@ -131,6 +131,7 @@ export default function ScenePanel({ project, outlineNodeId, chapterTitle, chapt
       setExpanded(true)
       await generateScenes()
     } catch (error) {
+      console.error('[ScenePanel] 场景细纲生成失败:', error)
       toast.error(error instanceof Error ? error.message : '场景细纲生成失败，请重试。')
     }
   }

--- a/src/components/shared/AIStreamOutput.tsx
+++ b/src/components/shared/AIStreamOutput.tsx
@@ -47,7 +47,9 @@ export default function AIStreamOutput({
   editable = false,
 }: AIStreamOutputProps) {
   const [editableOutput, setEditableOutput] = useState(output)
-  useEffect(() => setEditableOutput(output), [output])
+  useEffect(() => {
+    if (editable && !isStreaming) setEditableOutput(output)
+  }, [editable, isStreaming, output])
   const displayedOutput = editable && !isStreaming ? editableOutput : output
   const hasOutput = displayedOutput.length > 0
   const [marked, setMarked] = useState<'good' | 'bad' | null>(null)

--- a/src/lib/context-gateway/canon-provider.ts
+++ b/src/lib/context-gateway/canon-provider.ts
@@ -1,5 +1,9 @@
 import { estimateTokens } from '../ai/context-budget'
-import { normalizeChapterText, sha256Text } from '../ai/chapter-memory/text-normalization'
+import {
+  CHAPTER_TEXT_NORMALIZATION_VERSION,
+  normalizeChapterText,
+  sha256Text,
+} from '../ai/chapter-memory/text-normalization'
 import { canonicalStringify, hashCanonicalValue } from '../agent/run/hash'
 import { db } from '../db/schema'
 import { FIELD_BY_TARGET } from '../registry/field-registry'
@@ -520,10 +524,16 @@ async function chapterDerivedAuthority(row: ResourceRow, field: string): Promise
   if (!['summary', 'continuityHandoff', 'planReconciliation'].includes(field)) return 'author-canon'
   const content = typeof row.content === 'string' ? normalizeChapterText(row.content) : ''
   const currentHash = await sha256Text(content)
+  const derivedValue = row[field] as { sourceTextHash?: unknown; textNormalizationVersion?: unknown } | undefined
+  const normalizationVersion = field === 'summary'
+    ? row.summaryTextNormalizationVersion
+    : derivedValue?.textNormalizationVersion
   const expected = field === 'summary'
     ? row.summarySourceTextHash
-    : (row[field] as { sourceTextHash?: unknown } | undefined)?.sourceTextHash
-  return expected === currentHash ? 'derived-summary' : 'candidate'
+    : derivedValue?.sourceTextHash
+  return expected === currentHash && normalizationVersion === CHAPTER_TEXT_NORMALIZATION_VERSION
+    ? 'derived-summary'
+    : 'candidate'
 }
 
 async function authorityFor(spec: ResourceSpec, row: ResourceRow, field?: string): Promise<ContextResourceAuthorityV1> {
@@ -786,16 +796,23 @@ async function nestedChapterContinuity(
   if (spec.name !== 'chapters' || typeof row.content !== 'string' || !row.content.trim()) return []
   const plain = normalizeChapterText(row.content)
   const tail = plain.slice(-4_000)
-  const fields = ['content', 'summary', 'continuityHandoff', 'planReconciliation']
-    .filter(field => row[field] !== undefined && exactValue(row[field]).trim())
+  const derivedFields = (await Promise.all(
+    ['summary', 'continuityHandoff', 'planReconciliation'].map(async field => {
+      if (row[field] === undefined || !exactValue(row[field]).trim()) return null
+      const authority = await chapterDerivedAuthority(row, field)
+      return authority === 'candidate' ? null : { field, authority }
+    }),
+  )).filter((item): item is NonNullable<typeof item> => item != null)
+  const includedDerivedFields = new Set(derivedFields.map(item => item.field))
+  const fields = ['content', ...derivedFields.map(item => item.field)]
   const refs = await Promise.all(fields.map(field => sourceRef(spec, row, field, exactValue(row[field]))))
   const relations = await relationsForRow(spec, row)
   const body = [
     '【章节直接连续性】',
     `章节：${rowTitle(spec, row)}`,
-    row.summary ? `已验摘要：${exactValue(row.summary)}` : '',
-    row.continuityHandoff ? `交接：${exactValue(row.continuityHandoff)}` : '',
-    row.planReconciliation ? `计划对账：${exactValue(row.planReconciliation)}` : '',
+    includedDerivedFields.has('summary') ? `已验摘要：${exactValue(row.summary)}` : '',
+    includedDerivedFields.has('continuityHandoff') ? `交接：${exactValue(row.continuityHandoff)}` : '',
+    includedDerivedFields.has('planReconciliation') ? `计划对账：${exactValue(row.planReconciliation)}` : '',
     `原文尾部（最多 4000 字符）：\n${tail}`,
   ].filter(Boolean).join('\n')
   return [await makeDescriptor({
@@ -808,7 +825,10 @@ async function nestedChapterContinuity(
     fullContent: body,
     sourceRefs: refs,
     relations: [{ kind: 'parent', targetResourceKey: recordKey(spec, row), direction: 'outgoing' }, ...relations],
-    authority: await chapterDerivedAuthority(row, row.continuityHandoff ? 'continuityHandoff' : 'content'),
+    // The author-written tail is always Canon. Verified derived memory may
+    // enrich it, while stale/unverified memory is omitted instead of hiding the
+    // entire mandatory continuity resource as an undiscoverable candidate.
+    authority: conservativeAuthority(['author-canon', ...derivedFields.map(item => item.authority)]),
     policyField: 'content',
     timeRange: timeRangeForRow(spec.name, row),
   })]

--- a/src/lib/context-gateway/selector.ts
+++ b/src/lib/context-gateway/selector.ts
@@ -388,6 +388,17 @@ function normalizedTitle(value: string): string {
   return value.trim().toLocaleLowerCase('zh-CN').replace(/[\s·:：/／_-]+/g, '')
 }
 
+// A shared display title is only an identity conflict for resources whose name
+// identifies a durable entity. Facts, chapters, beats, outlines, and other
+// temporal/structural records may legitimately reuse a title while carrying
+// different content at different positions in the narrative.
+const SAME_NAME_CANON_IDENTITY_KINDS = new Set<ContextResourceKind>([
+  'character',
+  'location',
+  'codex-entry',
+  'story-arc',
+])
+
 function assertSelectorPolicy(policy: ContextSelectorPolicyV1, taskKind: AgentContextTaskKind): void {
   if (!AGENT_CONTEXT_TASK_KINDS.includes(taskKind) || policy.taskKind !== taskKind
     || policy.version !== CONTEXT_SELECTOR_VERSION_V1 || !policy.selectorPolicyId.trim()) {
@@ -838,7 +849,10 @@ export async function selectContextResourcesV1(input: ContextSelectorInputV1): P
     })
   }
   const titleGroups = new Map<string, ContextResourceDescriptorV1[]>()
-  for (const descriptor of available.filter(item => selectedKeys.has(item.resourceKey))) {
+  for (const descriptor of available.filter(item => (
+    selectedKeys.has(item.resourceKey)
+    && SAME_NAME_CANON_IDENTITY_KINDS.has(item.kind)
+  ))) {
     const title = `${descriptor.kind}:${normalizedTitle(descriptor.title)}`
     if (!title) continue
     titleGroups.set(title, [...(titleGroups.get(title) ?? []), descriptor])

--- a/src/lib/outline/detail-gateway-context.ts
+++ b/src/lib/outline/detail-gateway-context.ts
@@ -95,21 +95,36 @@ export async function prepareDetailedOutlineGatewayAssemblyV1(input: {
   const outlineOriginals = unique([originalOutlineKeys(target), ...adjacent.map(originalOutlineKeys)].flat())
 
   const currentDetail = details.find(row => row.outlineNodeId === input.outlineNodeId)
-  const detailKeys = currentDetail?.ragDocumentId
-    ? [`detailed-outline:${currentDetail.ragDocumentId}`]
+  // CONTEXT_SOURCES only exposes a detailed outline after it contains at least one
+  // scene. An empty placeholder row still has a stable resource id, but requiring
+  // that id here creates an impossible mandatory read before the first scene plan
+  // can be generated.
+  const registeredDetailResourceId = currentDetail?.ragDocumentId
+    && Array.isArray(currentDetail.scenes)
+    && currentDetail.scenes.length > 0
+    ? currentDetail.ragDocumentId
+    : null
+  const detailKeys = registeredDetailResourceId
+    ? [`detailed-outline:${registeredDetailResourceId}`]
     : []
-  const detailOriginalKeys = currentDetail?.ragDocumentId && Array.isArray(currentDetail.scenes) && currentDetail.scenes.length
-    ? [`detailed-outline:${currentDetail.ragDocumentId}:field:scenes`]
+  const detailOriginalKeys = registeredDetailResourceId
+    ? [`detailed-outline:${registeredDetailResourceId}:field:scenes`]
     : []
 
   const currentArcs = arcs.filter(row => inWorld(row, input.worldGroupId) && row.ragDocumentId)
   const arcKeys = currentArcs.map(row => `story-arc:${row.ragDocumentId}`)
-  const arcStageOriginals = currentArcs
-    .filter(row => typeof row.stages === 'string' && row.stages.trim())
-    .map(row => `story-arc:${row.ragDocumentId}:field:stages`)
-  const stageKeys = currentArcs.flatMap(row => typeof row.stages === 'string'
-    ? parseStages(row.stages).map(stage => `story-arc:${row.ragDocumentId}:stage:${encodeURIComponent(stage.id)}`)
-    : [])
+  // Canon intentionally omits empty JSON containers such as `[]`. Derive both
+  // the original field and nested stage requirements from the parsed stages so
+  // an empty placeholder can never become an impossible mandatory resource.
+  const currentArcStages = currentArcs.map(row => ({
+    row,
+    stages: typeof row.stages === 'string' ? parseStages(row.stages) : [],
+  }))
+  const arcStageOriginals = currentArcStages
+    .filter(({ stages }) => stages.length > 0)
+    .map(({ row }) => `story-arc:${row.ragDocumentId}:field:stages`)
+  const stageKeys = currentArcStages.flatMap(({ row, stages }) => stages
+    .map(stage => `story-arc:${row.ragDocumentId}:stage:${encodeURIComponent(stage.id)}`))
   const progressKeys = progress
     .filter(row => row.ragDocumentId && currentArcs.some(arc => arc.id === row.arcId))
     .map(row => `storyline-progress:${row.ragDocumentId}`)

--- a/tests/regression/R-AUDIT6-chapter-editor-toolbar.test.tsx
+++ b/tests/regression/R-AUDIT6-chapter-editor-toolbar.test.tsx
@@ -10,6 +10,7 @@ const mounted: Array<{ host: HTMLDivElement; root: ReturnType<typeof createRoot>
 async function mount(patch: Record<string, unknown> = {}) {
   const props = {
     isStreaming: false,
+    isPreparingGeneration: false,
     hasText: true,
     organizingChapter: false,
     hasOrganizationCandidate: false,
@@ -146,6 +147,16 @@ describe('AUDIT-6 / HEALTH-4 · 正文编辑器工具栏', () => {
     }
     expect(button(host, '停止整理').disabled).toBe(true)
     expect(button(host, '便签').disabled).toBe(false)
+  })
+
+  it('正文前置组装期间显示准备状态并阻止重复点击', async () => {
+    const { host, props } = await mount({ isPreparingGeneration: true })
+    const preparing = button(host, '准备中...')
+
+    expect(preparing.disabled).toBe(true)
+    await act(async () => preparing.click())
+    expect(props.onGenerate).not.toHaveBeenCalled()
+    expect(button(host, '📝 续写').disabled).toBe(true)
   })
 
   it('展示影响分析结果、开关状态并转发组合输入', async () => {

--- a/tests/regression/R-CTXG5-context-selector.test.ts
+++ b/tests/regression/R-CTXG5-context-selector.test.ts
@@ -227,6 +227,24 @@ describe('R-CTXG5 Context Gateway deterministic selector', () => {
     ]))
   })
 
+  it('allows same-title temporal facts to coexist without treating narrative history as an entity identity conflict', async () => {
+    const result = await selectContextResourcesV1({
+      taskKind: 'agent-prose',
+      accessPolicy: accessPolicy('agent-prose', 4_000),
+      scope,
+      descriptors: [
+        descriptor({ key: 'fact:w:beat-1', kind: 'fact', title: '情感节拍 · 情感节拍', tokens: 300 }),
+        descriptor({ key: 'fact:w:beat-2', kind: 'fact', title: '情感节拍 · 情感节拍', tokens: 300, revision: 2 }),
+      ],
+      budgetTokens: 4_000,
+      mandatoryResourceKeys: ['fact:w:beat-1', 'fact:w:beat-2'],
+      readsAllowed: true,
+    })
+
+    expect(result.selected.map(item => item.resourceKey)).toEqual(['fact:w:beat-1', 'fact:w:beat-2'])
+    expect(result.sufficiency.obligations.some(item => item.id.startsWith('same-name-conflict:'))).toBe(false)
+  })
+
   it('keeps cross-scope and implicit candidates out while allowing an explicitly keyed candidate', async () => {
     const resources = [
       descriptor({ key: 'character:w:canon', kind: 'character' }),

--- a/tests/regression/R-DETAIL1-gateway-scene-merge.test.ts
+++ b/tests/regression/R-DETAIL1-gateway-scene-merge.test.ts
@@ -204,6 +204,58 @@ describe('DETAIL-1 · 细纲 Gateway 与场景合并治理', () => {
     })).resolves.toMatchObject({ contextGatewayExecution: { path: 'deterministic-fast' } })
   })
 
+  it('空细纲占位记录不被误列为 mandatory resource，首次拆场景仍可运行', async () => {
+    const fixture = await seed()
+    const detail = await db.detailedOutlines.get(fixture.detailId)
+    await db.detailedOutlines.update(fixture.detailId, {
+      scenes: [],
+      openingHook: '',
+      endingCliffhanger: '',
+      sceneLocation: '',
+      lastUsedSummary: '',
+    })
+
+    const assembly = await prepareDetailedOutlineGatewayAssemblyV1({
+      projectId: fixture.projectId,
+      scope: fixture.scope,
+      worldGroupId: fixture.groupId,
+      outlineNodeId: fixture.targetId,
+      operation: 'scenes',
+      authorRequest: '首次拆分场景',
+      config: useAIConfigStore.getState().config,
+    })
+    const mandatory = new Set(assembly.contextGatewayExecution.retrievalTrace.mandatory.map(item => item.resourceKey))
+
+    expect(detail?.ragDocumentId).toBeTruthy()
+    expect(assembly.contextGatewayExecution.path).toBe('deterministic-fast')
+    expect(mandatory).not.toContain(`detailed-outline:${detail!.ragDocumentId}`)
+    expect(mandatory).not.toContain(`detailed-outline:${detail!.ragDocumentId}:field:scenes`)
+  })
+
+  it('空故事线阶段不被误列为 mandatory 原文，首次拆场景仍可运行', async () => {
+    const fixture = await seed()
+    const arc = await db.storyArcs.get(fixture.arcId)
+    await db.storyArcs.update(fixture.arcId, { stages: '[]' })
+
+    const assembly = await prepareDetailedOutlineGatewayAssemblyV1({
+      projectId: fixture.projectId,
+      scope: fixture.scope,
+      worldGroupId: fixture.groupId,
+      outlineNodeId: fixture.targetId,
+      operation: 'scenes',
+      authorRequest: '在故事线尚未分阶段时拆分场景',
+      config: useAIConfigStore.getState().config,
+    })
+    const mandatory = new Set(assembly.contextGatewayExecution.retrievalTrace.mandatory.map(item => item.resourceKey))
+    const arcResourceKey = `story-arc:${arc!.ragDocumentId}`
+
+    expect(arc?.ragDocumentId).toBeTruthy()
+    expect(assembly.contextGatewayExecution.path).toBe('deterministic-fast')
+    expect(mandatory).toContain(arcResourceKey)
+    expect(mandatory).not.toContain(`${arcResourceKey}:field:stages`)
+    expect([...mandatory].some(key => key.startsWith(`${arcResourceKey}:stage:`))).toBe(false)
+  })
+
   it('已有场景只能按稳定 sceneId 显式保留、修改、新增或删除，不允许无条件追加', () => {
     const currentScenes = [
       { sceneId: 'scene-a', title: '入门', summary: '守灯人进入潮门。', characterIds: [], location: '潮门', conflict: '是否前进', pace: 'medium' as const, estimatedWords: 800, notes: '保留' },

--- a/tests/regression/R-PROSE1-gateway-prose.test.ts
+++ b/tests/regression/R-PROSE1-gateway-prose.test.ts
@@ -239,6 +239,36 @@ describe.sequential('PROSE-1 · 正文 Gateway 单一上下文与 exact adoption
     expect(assembled.contextGatewayExecution.contextPacket.sourceRefs.some(ref => ref.table === 'narrativeChoices')).toBe(true)
   })
 
+  it('前章交接记忆过期时保留 Canon 正文尾部，并排除过期派生内容', async () => {
+    const fixture = await seed()
+    await db.chapters.update(fixture.priorChapterId, {
+      continuityHandoff: {
+        chapterId: fixture.priorChapterId,
+        sourceTextHash: '0'.repeat(64),
+        schemaVersion: 1,
+        extractorVersion: 'legacy-test',
+        textNormalizationVersion: 'legacy-normalization',
+        finalScene: { activeCharacters: [] },
+        stateChanges: [],
+        knowledgeChanges: [],
+        commitments: [],
+        openLoops: ['不应装入的过期交接'],
+        immediateNextIntent: '不应装入的过期交接',
+        evidenceQuotes: [],
+        generatedAt: now,
+      },
+    })
+
+    const assembled = await assemblyFor(fixture)
+    const priorChapter = await db.chapters.get(fixture.priorChapterId)
+    const continuityKey = `chapter:${priorChapter!.ragDocumentId}:continuity-tail`
+    const mandatory = new Set(assembled.contextGatewayExecution.retrievalTrace.mandatory.map(item => item.resourceKey))
+
+    expect(mandatory).toContain(continuityKey)
+    expect(assembled.text).toContain('镜片在潮声中苏醒')
+    expect(assembled.text).not.toContain('不应装入的过期交接')
+  })
+
   it('主 Agent 正文候选把 Gateway 实际来源写入输入状态证据并通过严格 Skill 校验', async () => {
     const fixture = await seed()
     await db.projects.update(fixture.projectId, { enableMultiWorld: true })

--- a/tests/regression/R-ai-stream-output-update-depth.test.tsx
+++ b/tests/regression/R-ai-stream-output-update-depth.test.tsx
@@ -1,0 +1,90 @@
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { create } from 'zustand'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import AIStreamOutput from '../../src/components/shared/AIStreamOutput'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+interface StreamState {
+  output: string
+  isStreaming: boolean
+}
+
+const useStreamState = create<StreamState>(() => ({
+  output: '',
+  isStreaming: true,
+}))
+
+const mounted: Array<{ root: ReturnType<typeof createRoot>; host: HTMLDivElement }> = []
+
+function Harness({ editable = false }: { editable?: boolean }) {
+  const output = useStreamState(state => state.output)
+  const isStreaming = useStreamState(state => state.isStreaming)
+  return createElement(AIStreamOutput, {
+    output,
+    isStreaming,
+    error: null,
+    editable,
+    onStop: () => undefined,
+    onRetry: () => undefined,
+  })
+}
+
+async function mount(editable = false) {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const root = createRoot(host)
+  mounted.push({ root, host })
+  await act(async () => root.render(createElement(Harness, { editable })))
+  return host
+}
+
+async function emitRapidStreamUpdates(count = 400) {
+  await act(async () => {
+    for (let index = 1; index <= count; index += 1) {
+      useStreamState.setState({ output: '字'.repeat(index * 12) })
+      await Promise.resolve()
+    }
+  })
+}
+
+afterEach(async () => {
+  while (mounted.length > 0) {
+    const item = mounted.pop()!
+    await act(async () => item.root.unmount())
+    item.host.remove()
+  }
+  useStreamState.setState({ output: '', isStreaming: true })
+  vi.restoreAllMocks()
+})
+
+describe('AIStreamOutput rapid stream updates', () => {
+  it('does not mirror non-editable stream chunks into nested local updates', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    await mount()
+
+    let thrown: unknown
+    try {
+      await emitRapidStreamUpdates()
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeUndefined()
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('Maximum update depth exceeded')
+  })
+
+  it('initializes the editable buffer once streaming finishes', async () => {
+    const host = await mount(true)
+    await emitRapidStreamUpdates(80)
+    const finalOutput = useStreamState.getState().output
+
+    await act(async () => {
+      useStreamState.setState({ isStreaming: false })
+    })
+
+    const editor = host.querySelector<HTMLTextAreaElement>('textarea[aria-label="AI 候选可编辑内容"]')
+    expect(editor?.value).toBe(finalOutput)
+  })
+})


### PR DESCRIPTION
## 改动说明 / What & Why

在实际使用“卷纲与章纲 → AI 生成本卷卷纲”时，模型已经流式返回约 3744 字，但前端随后报错：

```
Maximum update depth exceeded. This can happen when a component repeatedly calls setState...
```

定位后发现，`AIStreamOutput` 会在每个 `output` 分片到达后执行：

```tsx
useEffect(() => setEditableOutput(output), [output])
```

大纲生成使用共享 Zustand 会话保存流式输出；每个分片先触发一次外部 store 更新，上述 Effect 又触发一次组件本地更新。React 19 在服务商快速返回大量分片时会达到嵌套更新上限，生成流程因此被中断。该同步即使在 `editable=false` 时也会发生。

本 PR 将编辑缓冲区同步限制为“允许编辑且流式生成已经结束”：

```tsx
useEffect(() => {
  if (editable && !isStreaming) setEditableOutput(output)
}, [editable, isStreaming, output])
```

这样普通流式展示不再产生冗余本地更新，可编辑候选仍会在生成结束后载入最终文本。

## 复现与回归证据

新增回归测试模拟共享 store 连续推送 400 次流式更新：

- 普通流式输出不会再抛出 `Maximum update depth exceeded`
- 可编辑模式在流结束后仍能得到完整最终文本

修复前，同一最小复现会稳定触发该 React 错误；修复后 2/2 通过。

## 验证

- [x] 定向 Vitest：新增回归 2/2
- [x] `npx tsc --noEmit`
- [x] 修改文件定向 ESLint
- [x] 生产 `vite build`
- [x] `check:required-tables`
- [x] `git diff --check`
- [x] 已读 `AGENTS.md` 并按 `docs/CONTEXT-ROUTING.md` 定位相关代码
- [x] 不涉及 DB schema、三注册表、Prompt、模型请求或 Canon 写入

## 当前检出环境中的基线检查说明

本 PR 未修改相关区域，但 Windows 检出中另有两项全局检查未绿：

- `check:architecture`：报告 Gateway source keys 未从 `CONTEXT_SOURCES.resources` 派生；当前源码实际采用该派生写法，检查器使用精确换行字符串匹配。
- `check:ai-manual`：报告生成结果与已提交文件不一致。

建议由 CI 的标准检出环境给出最终结论；本 PR 只包含输出组件修复和对应回归测试。

## 自检清单 / Checklist

- [x] 改动遵循三注册表铁律
- [x] 修 bug 已有一条失败→变绿的反例测试
- [x] 未混入本地已有的 `package-lock.json` 改动
- [ ] `npm run ci` 本地全绿（见上方基线检查说明）
