### PR TITLE
docs(readme): 显示教程与 QQ 群并补齐九语言联系方式

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**Chinesische Anleitungen und Community:** [Bilibili-Video](https://www.bilibili.com/video/BV1q37j6QExh/) · [Zhihu-Einführung](https://zhuanlan.zhihu.com/p/2038714210188780594) · **QQ-Gruppe: 1082374587** · [Weitere Kontakte](#community)
+
 [Mit dem Schreiben beginnen](#quick-start) · [Fog Harbor ausprobieren](#try-a-story) · [Architektur ansehen](#architecture)
 
 StoryForge ist ein quelloffenes, lokal orientiertes Werkzeug für KI-gestütztes Erzählen und interaktive Geschichten. Schreibe Romane und kürzere Erzählungen, adaptiere einen Roman als Drehbuch oder Comic, entwickle wiederverwendbare Welten und erprobe interaktive Erlebnisse. Du wählst den Arbeitsablauf und bestätigst KI-Vorschläge, bevor sie Teil deines Werks werden.
@@ -249,7 +251,7 @@ Beispiel: Kapitel 8 hält fest, wer ein einzigartiges Objekt besitzt. Für Kapit
 
 ## Community und Mitarbeit
 
-[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Projektseite des Entwicklers](https://yuanbw.vercel.app/) · QQ-Gruppe: **1082374587**
+[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Projektseite des Entwicklers](https://yuanbw.vercel.app/) · [Zhihu-Profil des Entwicklers](https://www.zhihu.com/people/dan-ran-xing-yuan-59) · QQ-Gruppe: **1082374587**
 
 [Bilibili-Anleitung](https://www.bilibili.com/video/BV1q37j6QExh/) und [Zhihu-Einführung](https://zhuanlan.zhihu.com/p/2038714210188780594) sind ältere chinesische Ressourcen; Menüs können abweichen. Fehlerberichte sollten Version, Browser/Betriebssystem, Schritte sowie erwartetes und tatsächliches Ergebnis enthalten. Entferne Schlüssel und private Texte aus Bildern und Protokollen. Sterne, Beispiele, Videos, Übersetzungen und Beiträge sind willkommen.
 

--- a/README.en.md
+++ b/README.en.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**Chinese tutorials & community:** [Bilibili video](https://www.bilibili.com/video/BV1q37j6QExh/) · [Zhihu introduction](https://zhuanlan.zhihu.com/p/2038714210188780594) · **QQ group: 1082374587** · [More community links](#community-and-contributing)
+
 [Start creating](#quick-start) · [Try Fog Harbor](#try-an-original-story) · [Explore the architecture](#shared-execution-and-data-architecture)
 
 StoryForge is an open-source, local-first AI narrative creation and experience toolkit. Write long or short fiction, adapt a novel into a screenplay or comic, build reusable worlds, and explore character interaction and playable stories. You choose the workflow and approve AI candidates before they become part of your work.
@@ -287,6 +289,7 @@ Implementation: [formal prose runs](./src/lib/agent/run/prose-generation-durable
 - [Bilibili video guide](https://www.bilibili.com/video/BV1q37j6QExh/) and [Zhihu introduction](https://zhuanlan.zhihu.com/p/2038714210188780594): historical Chinese tutorials; menus may differ from current versions.
 - QQ community: **1082374587**.
 - [Developer's project site](https://yuanbw.vercel.app/) and [GitHub Issues](https://github.com/yuanbw2025/storyforge/issues).
+- [Developer’s Zhihu profile](https://www.zhihu.com/people/dan-ran-xing-yuan-59).
 
 For bugs, include the app version, browser/OS, steps, expected behavior and actual result. Remove secrets and private writing from screenshots and logs. Stars, tutorials, examples, translations and contributions are welcome.
 

--- a/README.es.md
+++ b/README.es.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**Tutoriales y comunidad en chino:** [Vídeo de Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) · [Introducción de Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594) · **Grupo QQ: 1082374587** · [Más contactos](#community)
+
 [Empieza a crear](#quick-start) · [Prueba Fog Harbor](#try-a-story) · [Explora la arquitectura](#architecture)
 
 StoryForge es una herramienta de código abierto para crear y vivir historias con IA, diseñada para conservar los datos en local. Escribe novelas y relatos breves, adapta novelas a guiones o cómics, construye mundos reutilizables y explora experiencias interactivas. Tú eliges el proceso y apruebas las propuestas de la IA antes de incorporarlas a tu obra.
@@ -249,7 +251,7 @@ Ejemplo: el capítulo 8 establece quién tiene un objeto único. En el capítulo
 
 ## Comunidad y contribuciones
 
-[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Sitio del desarrollador](https://yuanbw.vercel.app/) · Grupo QQ: **1082374587**
+[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Sitio del desarrollador](https://yuanbw.vercel.app/) · [Perfil de Zhihu del desarrollador](https://www.zhihu.com/people/dan-ran-xing-yuan-59) · Grupo QQ: **1082374587**
 
 [Tutorial de Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) e [introducción de Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594): recursos históricos en chino cuyos menús pueden diferir. Al informar de errores, indica versión, navegador/sistema, pasos y resultado esperado/real. Elimina claves y textos privados de capturas y registros. Se agradecen estrellas, ejemplos, vídeos, traducciones y contribuciones.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**Tutoriels et communauté en chinois :** [Vidéo Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) · [Présentation Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594) · **Groupe QQ : 1082374587** · [Autres liens](#community)
+
 [Commencer à créer](#quick-start) · [Découvrir Fog Harbor](#try-a-story) · [Explorer l’architecture](#architecture)
 
 StoryForge est un outil open source de création et d’expérience narrative assistées par IA, conçu pour conserver les données en local. Écrivez des romans ou des récits courts, adaptez un roman en scénario ou en bande dessinée, créez des mondes réutilisables et explorez des histoires interactives. Vous choisissez le parcours et validez les propositions de l’IA avant leur intégration à votre œuvre.
@@ -249,7 +251,7 @@ Exemple : le chapitre 8 établit qui détient un objet unique. Au chapitre 80, l
 
 ## Communauté et contributions
 
-[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Site du développeur](https://yuanbw.vercel.app/) · Groupe QQ : **1082374587**
+[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Site du développeur](https://yuanbw.vercel.app/) · [Profil Zhihu du développeur](https://www.zhihu.com/people/dan-ran-xing-yuan-59) · Groupe QQ : **1082374587**
 
 [Tutoriel Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) et [présentation Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594) : ressources historiques en chinois, dont les menus peuvent différer. Pour signaler un problème, indiquez version, navigateur/système, étapes et résultat attendu/observé ; retirez clés et textes privés des captures et journaux. Étoiles, exemples, vidéos, traductions et contributions sont bienvenus.
 

--- a/README.it.md
+++ b/README.it.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**Tutorial e comunità in cinese:** [Video Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) · [Introduzione Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594) · **Gruppo QQ: 1082374587** · [Altri contatti](#community)
+
 [Inizia a creare](#quick-start) · [Prova Fog Harbor](#try-a-story) · [Esplora l’architettura](#architecture)
 
 StoryForge è uno strumento open source per creare e vivere storie con l’IA, progettato per conservare i dati in locale. Scrivi romanzi e narrativa breve, adatta un romanzo in sceneggiatura o fumetto, costruisci mondi riutilizzabili ed esplora esperienze interattive. Scegli il percorso e approvi le proposte dell’IA prima che entrino nella tua opera.
@@ -249,7 +251,7 @@ Esempio: il capitolo 8 stabilisce chi possiede un oggetto unico. Al capitolo 80,
 
 ## Comunità e contributi
 
-[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Sito del progetto](https://yuanbw.vercel.app/) · Gruppo QQ: **1082374587**
+[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Sito del progetto](https://yuanbw.vercel.app/) · [Profilo Zhihu dello sviluppatore](https://www.zhihu.com/people/dan-ran-xing-yuan-59) · Gruppo QQ: **1082374587**
 
 [Tutorial Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) e [introduzione Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594) sono risorse storiche in cinese; i menu possono differire. Per i bug indica versione, browser/sistema, passaggi e risultato previsto/effettivo. Rimuovi chiavi e manoscritti privati da schermate e registri. Stelle, esempi, video, traduzioni e contributi sono benvenuti.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**中国語のチュートリアル・コミュニティ：** [Bilibili 動画](https://www.bilibili.com/video/BV1q37j6QExh/) · [Zhihu 紹介記事](https://zhuanlan.zhihu.com/p/2038714210188780594) · **QQ グループ：1082374587** · [その他の連絡先](#community)
+
 [創作を始める](#quick-start) · [Fog Harbor を体験する](#try-a-story) · [アーキテクチャを見る](#architecture)
 
 StoryForge は、ローカルでのデータ保持を基本とする、オープンソースの AI 物語制作・体験ツールです。長編や短編の執筆、小説の脚本化・漫画化、再利用できる世界の構築、対話型の物語体験に取り組めます。制作方法は作者が選び、AI の提案は確認・承認してから作品に取り込みます。
@@ -249,7 +251,7 @@ flowchart TB
 
 ## コミュニティと貢献
 
-[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [開発者サイト](https://yuanbw.vercel.app/) · QQ グループ：**1082374587**
+[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [開発者サイト](https://yuanbw.vercel.app/) · [開発者の Zhihu プロフィール](https://www.zhihu.com/people/dan-ran-xing-yuan-59) · QQ グループ：**1082374587**
 
 [Bilibili 動画](https://www.bilibili.com/video/BV1q37j6QExh/)と[Zhihu 紹介](https://zhuanlan.zhihu.com/p/2038714210188780594)は過去の中国語資料です。現在とメニューが異なる場合があります。不具合報告にはバージョン、ブラウザー・OS、再現手順、期待結果・実際の結果を添え、画像やログからキーと私的な原稿を除いてください。Star、作例、動画、翻訳、開発への参加を歓迎します。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**중국어 튜토리얼·커뮤니티:** [Bilibili 동영상](https://www.bilibili.com/video/BV1q37j6QExh/) · [Zhihu 소개 글](https://zhuanlan.zhihu.com/p/2038714210188780594) · **QQ 그룹: 1082374587** · [다른 연락처](#community)
+
 [창작 시작하기](#quick-start) · [Fog Harbor 체험하기](#try-a-story) · [아키텍처 살펴보기](#architecture)
 
 StoryForge는 데이터를 로컬에 보관하는 방식을 기본으로 하는 오픈 소스 AI 서사 창작·체험 도구입니다. 장편과 단편을 쓰고, 소설을 시나리오나 만화로 각색하고, 재사용할 세계를 만들고, 상호작용형 이야기를 탐색할 수 있습니다. 작업 방식은 작가가 선택하며, AI 제안은 작가의 확인과 승인을 거쳐 작품에 반영됩니다.
@@ -249,7 +251,7 @@ flowchart TB
 
 ## 커뮤니티와 기여
 
-[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [개발자 사이트](https://yuanbw.vercel.app/) · QQ 그룹: **1082374587**
+[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [개발자 사이트](https://yuanbw.vercel.app/) · [개발자 Zhihu 프로필](https://www.zhihu.com/people/dan-ran-xing-yuan-59) · QQ 그룹: **1082374587**
 
 [Bilibili 동영상](https://www.bilibili.com/video/BV1q37j6QExh/)과 [Zhihu 소개](https://zhuanlan.zhihu.com/p/2038714210188780594)는 과거의 중국어 자료로 현재 메뉴와 다를 수 있습니다. 오류 보고에는 버전, 브라우저·OS, 재현 단계, 예상 결과와 실제 결과를 적고 이미지·로그에서 키와 비공개 원고를 제거하세요. Star, 예제, 영상, 번역, 개발 기여를 환영합니다.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**教程与交流：** [B 站视频教程](https://www.bilibili.com/video/BV1q37j6QExh/) · [知乎专栏](https://zhuanlan.zhihu.com/p/2038714210188780594) · **QQ 交流群：1082374587** · [更多联系方式](#交流与支持)
+
 <p align="center">开源、本地优先的 AI 叙事创作与体验工具。创作长短篇小说，将小说改编成剧本或漫画；也可以派生世界，制作跑团等互动体验。</p>
 
 <p align="center">

--- a/README.pt.md
+++ b/README.pt.md
@@ -6,6 +6,8 @@
 [简体中文](./README.md) · [English](./README.en.md) · [Français](./README.fr.md) · [Deutsch](./README.de.md) · [Italiano](./README.it.md) · [Español](./README.es.md) · [Português](./README.pt.md) · [日本語](./README.ja.md) · [한국어](./README.ko.md)
 <!-- readme-languages:end -->
 
+**Tutoriais e comunidade em chinês:** [Vídeo Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) · [Introdução Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594) · **Grupo QQ: 1082374587** · [Mais contatos](#community)
+
 [Comece a criar](#quick-start) · [Experimente Fog Harbor](#try-a-story) · [Explore a arquitetura](#architecture)
 
 StoryForge é uma ferramenta de código aberto para criar e vivenciar narrativas com IA, projetada para manter os dados localmente. Escreva romances e narrativas curtas, adapte um romance para roteiro ou quadrinhos, construa mundos reutilizáveis e explore experiências interativas. Você escolhe o processo e aprova as propostas da IA antes de incorporá-las à sua obra.
@@ -249,7 +251,7 @@ Exemplo: o capítulo 8 estabelece quem possui um objeto único. No capítulo 80,
 
 ## Comunidade e contribuições
 
-[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Site do desenvolvedor](https://yuanbw.vercel.app/) · Grupo QQ: **1082374587**
+[GitHub Issues](https://github.com/yuanbw2025/storyforge/issues) · [Site do desenvolvedor](https://yuanbw.vercel.app/) · [Perfil Zhihu do desenvolvedor](https://www.zhihu.com/people/dan-ran-xing-yuan-59) · Grupo QQ: **1082374587**
 
 [Tutorial Bilibili](https://www.bilibili.com/video/BV1q37j6QExh/) e [introdução Zhihu](https://zhuanlan.zhihu.com/p/2038714210188780594) são recursos históricos em chinês; menus podem diferir. Para relatar bugs, informe versão, navegador/sistema, passos e resultados esperado/real. Remova chaves e textos privados das capturas e registros. Estrelas, exemplos, vídeos, traduções e contribuições são bem-vindos.
 


### PR DESCRIPTION
## 用户结果

在九种语言 README 顶部直接展示 B 站教程、知乎专栏、QQ 交流群 1082374587，并链接到详细联系方式。首次访问者无需翻到长文末尾寻找社区；英文及另外七个翻译版本补回开发者知乎主页。

## 来源与范围

回查全部可达历史中的 46 个 README 版本，确认原有入口来自 `0d14642a`、`bb2dff2b`、`febdc052` 等历史提交。当前中文 README 底部已保留这些地址，本次保留详细列表并增加首屏快捷入口，补齐各语言遗漏项。

只修改九个 L4 用户首页；不涉及应用界面、AI 调用、数据表、迁移、版本或媒资所有权。保留现有产品能力、架构图、演示、备份与赞助说明。

## 验证

- `npm run check:docs`、`git diff --check` 通过。
- 九语言共 610 个本地链接与锚点通过检查；各版本均包含历史联系地址集合，视频、知乎专栏与 QQ 群号出现在首个章节前。
- 浏览器首屏检查通过：中文教程入口与群号清晰可见。
- 外部地址按仓库历史核对。个人网站可读取；B 站和知乎的自动读取受站点限制，未将其当作链接失效，也未替换原目标。
- 完整本地 `npm run ci` 通过：523 个测试文件、2,537 项测试，依赖审计、架构、类型、构建与包体积检查通过。
- 当前 PR head `ef60504e` 的[远程 CI](https://github.com/yuanbw2025/storyforge/actions/runs/34448737225) 全部通过，含 71 项 Chromium E2E。
- CI 期间主干推进到 `ac33cb85`，仅追加三份流量 CSV。已在本地整合该主干与 PR head，并再次通过完整 `npm run ci`；最终验证树为 `f8bc24f7ce0031e420a627f19ab5bd465cc39ff8`。远程 E2E 对应原 PR head，本次流量归档未修改应用、测试或配置。已合并为 `da5bdb23`，确认远程主干树与本地验证树完全一致，PR head 已成为主干祖先。

无数据迁移。需要回退时撤销本次 README 文案改动即可。
